### PR TITLE
feat: route "/userfeeds/<feed-eid>/content/<feed-content-eid>", afficher les contenus d'un flux.

### DIFF
--- a/src/app/[locale]/(userfeeds)/userfeeds/[slug]/content/[feedContentEID]/route.tsx
+++ b/src/app/[locale]/(userfeeds)/userfeeds/[slug]/content/[feedContentEID]/route.tsx
@@ -1,0 +1,37 @@
+import { notFound } from "next/navigation";
+import { type NextRequest, NextResponse } from "next/server";
+import { feedService } from "@/app/[locale]/lib/feed-service";
+
+export async function GET(
+	_request: NextRequest,
+	{ params }: { params: Promise<{ feedContentEID: string }> },
+) {
+	const { feedContentEID } = await params;
+	if (!feedContentEID) {
+		return notFound();
+	}
+
+	const { content, error } = await feedService.getFeedContent(feedContentEID);
+	if (error) {
+		switch (error) {
+			case "not-found":
+				return new NextResponse("Content not found", { status: 404 });
+
+			case "invalid-eid":
+				return new NextResponse("Invalid content ID", { status: 400 });
+			default:
+				return new NextResponse("Error getting content", { status: 500 });
+		}
+	}
+
+	if (!content) {
+		return new NextResponse("Error generating feed", { status: 500 });
+	}
+
+	return new NextResponse(content, {
+		headers: {
+			"Content-Type": "text/html; charset=utf-8",
+			"Cache-Control": "public, max-age=3600",
+		},
+	});
+}

--- a/src/app/[locale]/lib/feed-service.ts
+++ b/src/app/[locale]/lib/feed-service.ts
@@ -305,12 +305,6 @@ const getFeedContent = cache(
 				return { error: "invalid-eid", content: null };
 			}
 
-			/*
-  		select content
-  		from feeds_content
-  		where url LIKE 'https://bocal.fyi/userfeeds/%/content/b2b3ada4-b5b3-438b-9e25-f775022f9331'
-		*/
-
 			const feedContent = await db
 				.select({
 					content: feedsContent.content,

--- a/src/app/[locale]/lib/feed-service.ts
+++ b/src/app/[locale]/lib/feed-service.ts
@@ -1,4 +1,4 @@
-import { eq, sql } from "drizzle-orm";
+import { eq, like, sql } from "drizzle-orm";
 import { Feed as FeedCreator } from "feed";
 import { decode } from "html-entities";
 import { cache } from "react";
@@ -14,6 +14,7 @@ import {
 import { db } from "@/db/db";
 import { type Feed, feeds, feedsContent } from "@/db/schema";
 import "server-only";
+import { userfeedsfuncs } from "@/app/[locale]/lib/userfeeds-funcs";
 
 const USER_AGENT = "RSS https://bocal.fyi/1.0";
 const SYNC_BATCH_SIZE = 10;
@@ -196,7 +197,7 @@ const generateUserAtomFeed = cache(
 			// Ex: “eid → feed → newsletterOwnerId → user → check payment/free trial status”
 			logger.warn("TODO: make sure the user is paying or is in trial");
 
-			// Check if eid is a valid uuid
+			// Check if eid is a valid uuid.
 			if (!z.uuid().safeParse(eid).success) {
 				return { error: "invalid-eid", atom: null };
 			}
@@ -211,7 +212,8 @@ const generateUserAtomFeed = cache(
 					lastSyncAt: feeds.lastSyncAt,
 				})
 				.from(feeds)
-				.where(eq(feeds.eid, eid));
+				.where(eq(feeds.eid, eid))
+				.limit(1);
 
 			if (!feed || feed.length === 0) {
 				return { error: "feed-not-found", atom: null };
@@ -268,6 +270,74 @@ const generateUserAtomFeed = cache(
 	},
 );
 
+type GetFeedContentResponse = {
+	error: "not-found" | "invalid-eid" | null;
+	content: string | null;
+};
+
+/**
+ * getFeedContent returns a specific content inside a feed.
+ * This is not checking if the user is authenticated
+ * because this is used in `bocal.fyi/userfeeds/<feed-eid>/content/<feed-content-eid>`,
+ * where the feed needs to be accessible without authentication.
+ * E.g. A user could look at the content using another feed reader (e.g. Feedly, NewsBlur, etc.).
+ *
+ * This also makes sure that the user owning the feed has an active
+ * subscription or is in trial.
+ * As long as the user owning this user feed has an active subscription or is in trial,
+ *  the feed content is accessible.
+ * We don't care how it is accessed.
+ * We only want that the user is paying.
+ *
+ * @param eid - External id of the feed_content.
+ *
+ */
+const getFeedContent = cache(
+	async (eid: string): Promise<GetFeedContentResponse> => {
+		try {
+			// Todo: make sure the user is paying or is in trial
+			// E.g
+			// Ex: “eid → feed → newsletterOwnerId → user → check payment/free trial status”
+			logger.warn("TODO: make sure the user is paying or is in trial");
+
+			// Check if eid is a valid uuid.
+			if (!z.uuid().safeParse(eid).success) {
+				return { error: "invalid-eid", content: null };
+			}
+
+			/*
+  		select content
+  		from feeds_content
+  		where url LIKE 'https://bocal.fyi/userfeeds/%/content/b2b3ada4-b5b3-438b-9e25-f775022f9331'
+		*/
+
+			const feedContent = await db
+				.select({
+					content: feedsContent.content,
+				})
+				.from(feedsContent)
+				.where(
+					like(
+						feedsContent.url,
+						`${userfeedsfuncs.NEWSLETTER_URL_PREFIX}%/content/${eid}`,
+					),
+				)
+				.limit(1);
+
+			if (!feedContent.length) {
+				return { error: "not-found", content: null };
+			}
+
+			const sanitized = parsing.sanitizeHTML(feedContent[0].content);
+
+			return { error: null, content: sanitized };
+		} catch (err) {
+			logger.error(err);
+			throw new Error("errors.unexpected");
+		}
+	},
+);
+
 /**
  * feedService contient les fonctions pour gérer les flux RSS.
  */
@@ -278,4 +348,5 @@ export const feedService = {
 	FeedTimeout,
 	triggerBackgroundSync,
 	generateUserAtomFeed,
+	getFeedContent,
 };

--- a/src/app/[locale]/lib/parsing.ts
+++ b/src/app/[locale]/lib/parsing.ts
@@ -21,8 +21,21 @@ const readableUrl = (url: string): string => {
  */
 function sanitizeHTML(html: string): string {
 	return DOMPurify.sanitize(html, {
-		ALLOWED_TAGS: ["p", "a", "b", "i", "em", "strong", "br"],
-		ALLOWED_ATTR: ["href"],
+		ALLOWED_TAGS: [
+			"p",
+			"a",
+			"b",
+			"i",
+			"em",
+			"strong",
+			"br",
+			"img",
+			"figure",
+			"figcaption",
+			"video",
+			"audio",
+		],
+		ALLOWED_ATTR: ["href", "src", "alt", "width", "height"],
 	});
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added the ability to fetch and view specific feed content by its unique ID via a dedicated route.
	- Improved error handling with clear status messages for missing, invalid, or unavailable content.
	- Enhanced performance with public caching of feed content for up to one hour.
	- Expanded support for richer feed content including images, figures, captions, and multimedia elements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->