### PR TITLE
feat: cacher les contenus déjà lus dans flux

### DIFF
--- a/drizzle/0012_spotty_shooting_star.sql
+++ b/drizzle/0012_spotty_shooting_star.sql
@@ -1,0 +1,6 @@
+CREATE TABLE "users_preferences" (
+	"userId" text PRIMARY KEY NOT NULL,
+	"prefs" jsonb NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "users_preferences" ADD CONSTRAINT "users_preferences_userId_users_id_fk" FOREIGN KEY ("userId") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;

--- a/drizzle/0013_short_zarda.sql
+++ b/drizzle/0013_short_zarda.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "users" DROP CONSTRAINT "feedContentLimit_check";--> statement-breakpoint
+ALTER TABLE "users" DROP COLUMN "feedContentLimit";

--- a/drizzle/meta/0012_snapshot.json
+++ b/drizzle/meta/0012_snapshot.json
@@ -1,0 +1,884 @@
+{
+  "id": "5273910e-905c-4516-b4f9-341ff593addd",
+  "prevId": "8f704dd6-c7af-437b-bf7e-a25cf10222a7",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "providerAccountId": {
+          "name": "providerAccountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_state": {
+          "name": "session_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "accounts_userId_users_id_fk": {
+          "name": "accounts_userId_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "accounts_provider_providerAccountId_pk": {
+          "name": "accounts_provider_providerAccountId_pk",
+          "columns": [
+            "provider",
+            "providerAccountId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.authenticators": {
+      "name": "authenticators",
+      "schema": "",
+      "columns": {
+        "credentialID": {
+          "name": "credentialID",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "providerAccountId": {
+          "name": "providerAccountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credentialPublicKey": {
+          "name": "credentialPublicKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "counter": {
+          "name": "counter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credentialDeviceType": {
+          "name": "credentialDeviceType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credentialBackedUp": {
+          "name": "credentialBackedUp",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transports": {
+          "name": "transports",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "authenticators_userId_users_id_fk": {
+          "name": "authenticators_userId_users_id_fk",
+          "tableFrom": "authenticators",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "authenticators_userId_credentialID_pk": {
+          "name": "authenticators_userId_credentialID_pk",
+          "columns": [
+            "userId",
+            "credentialID"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "authenticators_credentialID_unique": {
+          "name": "authenticators_credentialID_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "credentialID"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feeds": {
+      "name": "feeds",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "feeds_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "eid": {
+          "name": "eid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "newsletterOwnerId": {
+          "name": "newsletterOwnerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "lastSyncAt": {
+          "name": "lastSyncAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "lastError": {
+          "name": "lastError",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "errorCount": {
+          "name": "errorCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "errorType": {
+          "name": "errorType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "feeds_eid_index": {
+          "name": "feeds_eid_index",
+          "columns": [
+            {
+              "expression": "eid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "feeds_newsletterOwnerId_users_id_fk": {
+          "name": "feeds_newsletterOwnerId_users_id_fk",
+          "tableFrom": "feeds",
+          "tableTo": "users",
+          "columnsFrom": [
+            "newsletterOwnerId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "feeds_url_unique": {
+          "name": "feeds_url_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "url"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feeds_content": {
+      "name": "feeds_content",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "feeds_content_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "eid": {
+          "name": "eid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "feedId": {
+          "name": "feedId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "url_feedid": {
+          "name": "url_feedid",
+          "columns": [
+            {
+              "expression": "url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "feedId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "feeds_content_eid_index": {
+          "name": "feeds_content_eid_index",
+          "columns": [
+            {
+              "expression": "eid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "feeds_content_feedId_feeds_id_fk": {
+          "name": "feeds_content_feedId_feeds_id_fk",
+          "tableFrom": "feeds_content",
+          "tableTo": "feeds",
+          "columnsFrom": [
+            "feedId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.links": {
+      "name": "links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "links_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ogTitle": {
+          "name": "ogTitle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ogImageURL": {
+          "name": "ogImageURL",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isArchived": {
+          "name": "isArchived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "links_userId_users_id_fk": {
+          "name": "links_userId_users_id_fk",
+          "tableFrom": "links",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "sessionToken": {
+          "name": "sessionToken",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_userId_users_id_fk": {
+          "name": "sessions_userId_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feedContentLimit": {
+          "name": "feedContentLimit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 10
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "feedContentLimit_check": {
+          "name": "feedContentLimit_check",
+          "value": "\"users\".\"feedContentLimit\" > 0 AND \"users\".\"feedContentLimit\" <= 100"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.users_feeds": {
+      "name": "users_feeds",
+      "schema": "",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "feedId": {
+          "name": "feedId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "users_feeds_userId_users_id_fk": {
+          "name": "users_feeds_userId_users_id_fk",
+          "tableFrom": "users_feeds",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "users_feeds_feedId_feeds_id_fk": {
+          "name": "users_feeds_feedId_feeds_id_fk",
+          "tableFrom": "users_feeds",
+          "tableTo": "feeds",
+          "columnsFrom": [
+            "feedId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "users_feeds_userId_feedId_pk": {
+          "name": "users_feeds_userId_feedId_pk",
+          "columns": [
+            "userId",
+            "feedId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users_feeds_read_content": {
+      "name": "users_feeds_read_content",
+      "schema": "",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "feedId": {
+          "name": "feedId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "feedContentId": {
+          "name": "feedContentId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "readAt": {
+          "name": "readAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "users_feeds_read_content_userId_users_id_fk": {
+          "name": "users_feeds_read_content_userId_users_id_fk",
+          "tableFrom": "users_feeds_read_content",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "users_feeds_read_content_feedId_feeds_id_fk": {
+          "name": "users_feeds_read_content_feedId_feeds_id_fk",
+          "tableFrom": "users_feeds_read_content",
+          "tableTo": "feeds",
+          "columnsFrom": [
+            "feedId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "users_feeds_read_content_feedContentId_feeds_content_id_fk": {
+          "name": "users_feeds_read_content_feedContentId_feeds_content_id_fk",
+          "tableFrom": "users_feeds_read_content",
+          "tableTo": "feeds_content",
+          "columnsFrom": [
+            "feedContentId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "users_feeds_read_content_userId_feedId_feedContentId_pk": {
+          "name": "users_feeds_read_content_userId_feedId_feedContentId_pk",
+          "columns": [
+            "userId",
+            "feedId",
+            "feedContentId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users_preferences": {
+      "name": "users_preferences",
+      "schema": "",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "prefs": {
+          "name": "prefs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "users_preferences_userId_users_id_fk": {
+          "name": "users_preferences_userId_users_id_fk",
+          "tableFrom": "users_preferences",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification_tokens": {
+      "name": "verification_tokens",
+      "schema": "",
+      "columns": {
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "verification_tokens_identifier_token_pk": {
+          "name": "verification_tokens_identifier_token_pk",
+          "columns": [
+            "identifier",
+            "token"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/0013_snapshot.json
+++ b/drizzle/meta/0013_snapshot.json
@@ -1,0 +1,872 @@
+{
+  "id": "86998b80-4969-4625-96d5-21577573e736",
+  "prevId": "5273910e-905c-4516-b4f9-341ff593addd",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "providerAccountId": {
+          "name": "providerAccountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_state": {
+          "name": "session_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "accounts_userId_users_id_fk": {
+          "name": "accounts_userId_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "accounts_provider_providerAccountId_pk": {
+          "name": "accounts_provider_providerAccountId_pk",
+          "columns": [
+            "provider",
+            "providerAccountId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.authenticators": {
+      "name": "authenticators",
+      "schema": "",
+      "columns": {
+        "credentialID": {
+          "name": "credentialID",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "providerAccountId": {
+          "name": "providerAccountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credentialPublicKey": {
+          "name": "credentialPublicKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "counter": {
+          "name": "counter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credentialDeviceType": {
+          "name": "credentialDeviceType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credentialBackedUp": {
+          "name": "credentialBackedUp",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transports": {
+          "name": "transports",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "authenticators_userId_users_id_fk": {
+          "name": "authenticators_userId_users_id_fk",
+          "tableFrom": "authenticators",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "authenticators_userId_credentialID_pk": {
+          "name": "authenticators_userId_credentialID_pk",
+          "columns": [
+            "userId",
+            "credentialID"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "authenticators_credentialID_unique": {
+          "name": "authenticators_credentialID_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "credentialID"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feeds": {
+      "name": "feeds",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "feeds_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "eid": {
+          "name": "eid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "newsletterOwnerId": {
+          "name": "newsletterOwnerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "lastSyncAt": {
+          "name": "lastSyncAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "lastError": {
+          "name": "lastError",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "errorCount": {
+          "name": "errorCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "errorType": {
+          "name": "errorType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "feeds_eid_index": {
+          "name": "feeds_eid_index",
+          "columns": [
+            {
+              "expression": "eid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "feeds_newsletterOwnerId_users_id_fk": {
+          "name": "feeds_newsletterOwnerId_users_id_fk",
+          "tableFrom": "feeds",
+          "tableTo": "users",
+          "columnsFrom": [
+            "newsletterOwnerId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "feeds_url_unique": {
+          "name": "feeds_url_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "url"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feeds_content": {
+      "name": "feeds_content",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "feeds_content_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "eid": {
+          "name": "eid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "feedId": {
+          "name": "feedId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "url_feedid": {
+          "name": "url_feedid",
+          "columns": [
+            {
+              "expression": "url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "feedId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "feeds_content_eid_index": {
+          "name": "feeds_content_eid_index",
+          "columns": [
+            {
+              "expression": "eid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "feeds_content_feedId_feeds_id_fk": {
+          "name": "feeds_content_feedId_feeds_id_fk",
+          "tableFrom": "feeds_content",
+          "tableTo": "feeds",
+          "columnsFrom": [
+            "feedId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.links": {
+      "name": "links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "links_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ogTitle": {
+          "name": "ogTitle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ogImageURL": {
+          "name": "ogImageURL",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isArchived": {
+          "name": "isArchived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "links_userId_users_id_fk": {
+          "name": "links_userId_users_id_fk",
+          "tableFrom": "links",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "sessionToken": {
+          "name": "sessionToken",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_userId_users_id_fk": {
+          "name": "sessions_userId_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users_feeds": {
+      "name": "users_feeds",
+      "schema": "",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "feedId": {
+          "name": "feedId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "users_feeds_userId_users_id_fk": {
+          "name": "users_feeds_userId_users_id_fk",
+          "tableFrom": "users_feeds",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "users_feeds_feedId_feeds_id_fk": {
+          "name": "users_feeds_feedId_feeds_id_fk",
+          "tableFrom": "users_feeds",
+          "tableTo": "feeds",
+          "columnsFrom": [
+            "feedId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "users_feeds_userId_feedId_pk": {
+          "name": "users_feeds_userId_feedId_pk",
+          "columns": [
+            "userId",
+            "feedId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users_feeds_read_content": {
+      "name": "users_feeds_read_content",
+      "schema": "",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "feedId": {
+          "name": "feedId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "feedContentId": {
+          "name": "feedContentId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "readAt": {
+          "name": "readAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "users_feeds_read_content_userId_users_id_fk": {
+          "name": "users_feeds_read_content_userId_users_id_fk",
+          "tableFrom": "users_feeds_read_content",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "users_feeds_read_content_feedId_feeds_id_fk": {
+          "name": "users_feeds_read_content_feedId_feeds_id_fk",
+          "tableFrom": "users_feeds_read_content",
+          "tableTo": "feeds",
+          "columnsFrom": [
+            "feedId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "users_feeds_read_content_feedContentId_feeds_content_id_fk": {
+          "name": "users_feeds_read_content_feedContentId_feeds_content_id_fk",
+          "tableFrom": "users_feeds_read_content",
+          "tableTo": "feeds_content",
+          "columnsFrom": [
+            "feedContentId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "users_feeds_read_content_userId_feedId_feedContentId_pk": {
+          "name": "users_feeds_read_content_userId_feedId_feedContentId_pk",
+          "columns": [
+            "userId",
+            "feedId",
+            "feedContentId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users_preferences": {
+      "name": "users_preferences",
+      "schema": "",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "prefs": {
+          "name": "prefs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "users_preferences_userId_users_id_fk": {
+          "name": "users_preferences_userId_users_id_fk",
+          "tableFrom": "users_preferences",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification_tokens": {
+      "name": "verification_tokens",
+      "schema": "",
+      "columns": {
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "verification_tokens_identifier_token_pk": {
+          "name": "verification_tokens_identifier_token_pk",
+          "columns": [
+            "identifier",
+            "token"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -92,6 +92,13 @@
       "when": 1753086560526,
       "tag": "0012_spotty_shooting_star",
       "breakpoints": true
+    },
+    {
+      "idx": 13,
+      "version": "7",
+      "when": 1753318909121,
+      "tag": "0013_short_zarda",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -85,6 +85,13 @@
       "when": 1750561843130,
       "tag": "0011_cute_nighthawk",
       "breakpoints": true
+    },
+    {
+      "idx": 12,
+      "version": "7",
+      "when": 1753086560526,
+      "tag": "0012_spotty_shooting_star",
+      "breakpoints": true
     }
   ]
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -226,13 +226,9 @@
 		},
 		"viewSection": {
 			"title": "View",
-			"hideImages": {
-				"title": "Hide images",
-				"description": "Hide images in links."
-			},
-			"gridView": {
-				"title": "Grid view",
-				"description": "Use grid layout for links."
+			"hide": {
+				"title": "Hide read content",
+				"description": "Hide read content from the feeds timeline."
 			},
 			"feed": {
 				"title": "Feeds items limit",
@@ -240,7 +236,8 @@
 			},
 			"errors": {
 				"feedContentLimitFieldInvalid": "Content limit per feed invalid.",
-				"missingFields": "Missing fields."
+				"missingFields": "Missing fields.",
+				"unexpected": "Unexpected error occurred."
 			},
 			"success": "Settings saved",
 			"submit": "Save"

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -226,13 +226,9 @@
 		},
 		"viewSection": {
 			"title": "Affichage",
-			"hideImages": {
-				"title": "Masquer les images",
-				"description": "Masquer les images dans les liens."
-			},
-			"gridView": {
-				"title": "Vue en grille",
-				"description": "Afficher les liens en grille."
+			"hide": {
+				"title": "Masquer le contenu lu",
+				"description": "Masquer le contenu lu du flux"
 			},
 			"feed": {
 				"title": "Limite de contenu de flux",
@@ -240,7 +236,8 @@
 			},
 			"errors": {
 				"feedContentLimitFieldInvalid": "Limite de contenu par flux invalide.",
-				"missingFields": "Champ(s) manquant(s)."
+				"missingFields": "Champ(s) manquant(s).",
+				"unexpected": "Erreur inattendue."
 			},
 			"success": "Paramètres enregistrés",
 			"submit": "Enregistrer"

--- a/src/app/[locale]/(app)/d/(no-sidebar)/settings/page.tsx
+++ b/src/app/[locale]/(app)/d/(no-sidebar)/settings/page.tsx
@@ -1,9 +1,9 @@
 import type { Metadata } from "next";
-import { useTranslations } from "next-intl";
 import { getTranslations } from "next-intl/server";
 import { Suspense } from "react";
 import { Settings } from "@/app/[locale]/ui/settings/settings";
 import { SettingsSkeleton } from "@/app/[locale]/ui/skeletons";
+import { auth } from "@/auth";
 import { Separator } from "@/components/ui/separator";
 export const experimental_ppr = true;
 
@@ -21,8 +21,11 @@ export async function generateMetadata({
 	} satisfies Metadata;
 }
 
-export default function Page(): React.JSX.Element {
-	const t = useTranslations("settings");
+export default async function Page(): Promise<React.JSX.Element> {
+	const t = await getTranslations("settings");
+	const sess = await auth();
+
+	console.log(sess);
 
 	return (
 		<>

--- a/src/app/[locale]/(app)/d/(sidebar)/feeds/page.tsx
+++ b/src/app/[locale]/(app)/d/(sidebar)/feeds/page.tsx
@@ -60,11 +60,18 @@ async function FeedsHeaderWrapper(): Promise<React.JSX.Element> {
 }
 
 async function FeedsWrapper(): Promise<React.JSX.Element> {
-	const [timeline, limit] = await dal.getUserFeedsTimeline();
+	const [timeline, sess] = await Promise.all([
+		dal.getUserFeedsTimeline(),
+		dal.verifySession(),
+	]);
+
 	return (
 		<FeedsTimeline
 			timeline={timeline}
-			feedContentLimit={limit.feedContentLimit}
+			// At this point, we have verified the session and have access to the user's preferences.
+			// So we can assert with '!'.
+			// biome-ignore lint/style/noNonNullAssertion: it's defined.
+			userPreferences={sess!.user.preferences}
 		/>
 	);
 }

--- a/src/app/[locale]/lib/actions.ts
+++ b/src/app/[locale]/lib/actions.ts
@@ -629,11 +629,10 @@ export async function setHideReadFeedContent(
 			throw new Error("errors.notSignedIn");
 		}
 
-		const val = String(validatedFields.data.hideRead);
 		await db
 			.update(usersPreferences)
 			.set({
-				prefs: sql`jsonb_set(prefs, '{hideReadFeedContent}', ${val})`,
+				prefs: sql`jsonb_set(prefs, '{hideReadFeedContent}', ${hideRead})`,
 			})
 			.where(eq(usersPreferences.userId, user.user.id))
 			.execute();

--- a/src/app/[locale]/lib/actions.ts
+++ b/src/app/[locale]/lib/actions.ts
@@ -27,7 +27,6 @@ import {
 	insertUsersSchema,
 	links,
 	unfollowFeedSchema,
-	users,
 	usersFeeds,
 	usersFeedsReadContent,
 	usersPreferences,
@@ -578,9 +577,11 @@ export async function setFeedContentLimit(
 		}
 
 		await db
-			.update(users)
-			.set({ feedContentLimit: validatedFields.data.feedContentLimit })
-			.where(eq(users.id, user.user.id))
+			.update(usersPreferences)
+			.set({
+				prefs: sql`jsonb_set(prefs, '{feedContentLimit}', ${validatedFields.data.feedContentLimit})`,
+			})
+			.where(eq(usersPreferences.userId, user.user.id))
 			.execute();
 	} catch (err) {
 		logger.error(err);

--- a/src/app/[locale]/lib/actions.ts
+++ b/src/app/[locale]/lib/actions.ts
@@ -24,7 +24,6 @@ import {
 	insertFeedsSchema,
 	insertLinksSchema,
 	insertUsersFeedsReadContentSchema,
-	insertUsersSchema,
 	links,
 	unfollowFeedSchema,
 	usersFeeds,
@@ -552,15 +551,24 @@ export async function markFeedContentAsUnread(
 }
 
 export type SetFeedContentLimitState = State<{
-	feedContentLimit?: string;
+	feedContentLimit: number;
 }>;
 
 export async function setFeedContentLimit(
-	feedContentLimit: string,
+	feedContentLimit: number,
 ): Promise<SetFeedContentLimitState> {
-	const validatedFields = insertUsersSchema.safeParse({
-		feedContentLimit: Number.parseInt(feedContentLimit),
-	});
+	const validatedFields = z
+		.object({
+			feedContentLimit: z
+				.number()
+				.min(1, {
+					error: "errors.feedContentLimitFieldInvalid",
+				})
+				.max(2, {
+					error: "errors.feedContentLimitFieldInvalid",
+				}),
+		})
+		.safeParse({ feedContentLimit });
 
 	if (!validatedFields.success) {
 		return {

--- a/src/app/[locale]/lib/constants.ts
+++ b/src/app/[locale]/lib/constants.ts
@@ -53,3 +53,14 @@ export const APP_ROUTES = {
 	legalPrivacy: "/legal/privacy",
 	legalTerms: "/legal/terms",
 } as const;
+
+/**
+ * DEFAULT_USERS_PREFERENCES represent the default users preferences.
+ */
+export const DEFAULT_USERS_PREFERENCES = {
+	hideReadFeedContent: false,
+	feedContentLimit: 30,
+};
+
+// export type UserPreferenceKey = keyof typeof DEFAULT_USERS_PREFERENCES;
+// export type UserPreferenceType = typeof DEFAULT_USERS_PREFERENCES;

--- a/src/app/[locale]/lib/constants.ts
+++ b/src/app/[locale]/lib/constants.ts
@@ -55,12 +55,12 @@ export const APP_ROUTES = {
 } as const;
 
 /**
- * DEFAULT_USERS_PREFERENCES represent the default users preferences.
+ * DEFAULT_USERS_PREFERENCES represents the default users preferences.
  */
 export const DEFAULT_USERS_PREFERENCES = {
 	hideReadFeedContent: false,
 	feedContentLimit: 30,
 };
 
-// export type UserPreferenceKey = keyof typeof DEFAULT_USERS_PREFERENCES;
-// export type UserPreferenceType = typeof DEFAULT_USERS_PREFERENCES;
+export type UserPreferences = typeof DEFAULT_USERS_PREFERENCES;
+// export type UserPreferencesKey = keyof typeof DEFAULT_USERS_PREFERENCES;

--- a/src/app/[locale]/lib/dal.ts
+++ b/src/app/[locale]/lib/dal.ts
@@ -22,7 +22,7 @@ import { auth } from "@/auth";
 const ONE_HOUR = 60 * 60 * 1000;
 
 /**
- * verifySession vérifie la session actuelle.
+ * verifySession returns the current session (logged in user).
  */
 const verifySession = cache(async (): Promise<Session | null> => {
 	return await auth();

--- a/src/app/[locale]/ui/feeds/add-feed-form.tsx
+++ b/src/app/[locale]/ui/feeds/add-feed-form.tsx
@@ -106,7 +106,7 @@ const FeedForm = ({
 	const t = useTranslations("rssFeed");
 	const initialState: AddFeedState = {
 		errors: undefined,
-		errMessage: null,
+		defaultErrMessage: null,
 		data: undefined,
 	};
 	const [state, formAction, pending] = useActionState(addFeed, initialState);
@@ -142,8 +142,10 @@ const FeedForm = ({
 					</p>
 				))}
 
-				{state?.errMessage && (
-					<p className="mt-2 text-sm text-destructive">{t(state.errMessage)}</p>
+				{state?.defaultErrMessage && (
+					<p className="mt-2 text-sm text-destructive">
+						{t(state.defaultErrMessage)}
+					</p>
 				)}
 
 				{state?.successMessage && (

--- a/src/app/[locale]/ui/feeds/feed-context-menu.tsx
+++ b/src/app/[locale]/ui/feeds/feed-context-menu.tsx
@@ -46,8 +46,8 @@ function ArchiveFeedContent({ url }: Props): React.JSX.Element {
 		startTransition(async () => {
 			try {
 				const res = await archiveFeedContent(url);
-				if (res.errMessage) {
-					toast.error(t(res.errMessage));
+				if (res.defaultErrMessage) {
+					toast.error(t(res.defaultErrMessage));
 					return;
 				}
 			} catch (_err) {

--- a/src/app/[locale]/ui/feeds/feeds-header-context-menu.tsx
+++ b/src/app/[locale]/ui/feeds/feeds-header-context-menu.tsx
@@ -74,8 +74,8 @@ function UnfollowFeed(): React.JSX.Element {
 				if (selectedFeed === searchParamsState.DEFAULT_FEED) return;
 
 				const res = await unfollowFeed(selectedFeed);
-				if (res.errMessage) {
-					toast.error(t(res.errMessage));
+				if (res.defaultErrMessage) {
+					toast.error(t(res.defaultErrMessage));
 					return;
 				}
 

--- a/src/app/[locale]/ui/feeds/feeds-timeline.tsx
+++ b/src/app/[locale]/ui/feeds/feeds-timeline.tsx
@@ -65,8 +65,8 @@ const Item = ({ item }: { item: FeedTimeline }): React.JSX.Element => {
 				setIsRead(true);
 				const res = await markFeedContentAsRead(feedId, feedContentId);
 
-				if (res.errMessage) {
-					toast.error(t(res.errMessage));
+				if (res.defaultErrMessage) {
+					toast.error(t(res.defaultErrMessage));
 				}
 			} catch (_err) {
 				setIsRead(false);
@@ -84,8 +84,8 @@ const Item = ({ item }: { item: FeedTimeline }): React.JSX.Element => {
 				setIsRead(false);
 				const res = await markFeedContentAsUnread(feedId, feedContentId);
 
-				if (res.errMessage) {
-					toast.error(t(res.errMessage));
+				if (res.defaultErrMessage) {
+					toast.error(t(res.defaultErrMessage));
 				}
 			} catch (_err) {
 				setIsRead(true);

--- a/src/app/[locale]/ui/feeds/feeds-timeline.tsx
+++ b/src/app/[locale]/ui/feeds/feeds-timeline.tsx
@@ -37,13 +37,16 @@ export function FeedsTimeline({
 			if (selectedFeed === searchParamsState.DEFAULT_FEED) return true;
 			return el.feedId.toString() === selectedFeed;
 		})
+		.filter((el) => {
+			if (userPreferences.hideReadFeedContent && el.readAt !== null)
+				return false;
+			return true;
+		})
 		.slice(0, userPreferences.feedContentLimit);
 
 	return (
 		<section className={cn("wrap-anywhere", SPACING.LG)}>
 			{items.map((item) => {
-				if (userPreferences.hideReadFeedContent && item.readAt !== null)
-					return null;
 				return <Item item={item} key={`${item.id}`} />;
 			})}
 		</section>

--- a/src/app/[locale]/ui/feeds/feeds-timeline.tsx
+++ b/src/app/[locale]/ui/feeds/feeds-timeline.tsx
@@ -8,6 +8,7 @@ import {
 	markFeedContentAsRead,
 	markFeedContentAsUnread,
 } from "@/app/[locale]/lib/actions";
+import type { UserPreferences } from "@/app/[locale]/lib/constants";
 import { parsing } from "@/app/[locale]/lib/parsing";
 import { searchParamsState } from "@/app/[locale]/lib/stores/search-params-states";
 import { userfeedsfuncs } from "@/app/[locale]/lib/userfeeds-funcs";
@@ -20,15 +21,12 @@ import { cn } from "@/lib/utils";
 
 type Props = {
 	timeline: FeedTimeline[];
-	/**
-	 * The maximum number of items to show on the timeline.
-	 */
-	feedContentLimit: number;
+	userPreferences: UserPreferences;
 };
 
 export function FeedsTimeline({
 	timeline,
-	feedContentLimit,
+	userPreferences,
 }: Props): React.JSX.Element {
 	const [{ selectedFeed }] = useQueryStates(searchParamsState.searchParams, {
 		urlKeys: searchParamsState.urlKeys,
@@ -39,11 +37,13 @@ export function FeedsTimeline({
 			if (selectedFeed === searchParamsState.DEFAULT_FEED) return true;
 			return el.feedId.toString() === selectedFeed;
 		})
-		.slice(0, feedContentLimit);
+		.slice(0, userPreferences.feedContentLimit);
 
 	return (
 		<section className={cn("wrap-anywhere", SPACING.LG)}>
 			{items.map((item) => {
+				if (userPreferences.hideReadFeedContent && item.readAt !== null)
+					return null;
 				return <Item item={item} key={`${item.id}`} />;
 			})}
 		</section>

--- a/src/app/[locale]/ui/feeds/sidebar/feeds-sidebar-content.tsx
+++ b/src/app/[locale]/ui/feeds/sidebar/feeds-sidebar-content.tsx
@@ -13,7 +13,7 @@ export async function FeedsSidebarContent(): Promise<React.JSX.Element> {
 
 	return (
 		<SidebarMenu>
-			<FeedsSidebarMenuItemAll totalFeedsContents={timeline[0].length} />
+			<FeedsSidebarMenuItemAll totalFeedsContents={timeline.length} />
 
 			<SidebarMenuItem className="mt-4 px-2 text-xs font-md">
 				<span>

--- a/src/app/[locale]/ui/links/add-link-form.tsx
+++ b/src/app/[locale]/ui/links/add-link-form.tsx
@@ -105,7 +105,7 @@ function LinkForm({
 }: React.ComponentProps<"form">): React.JSX.Element {
 	const initialState: AddLinkState = {
 		errors: undefined,
-		errMessage: null,
+		defaultErrMessage: null,
 		data: undefined,
 	};
 	const t = useTranslations("dashboard");
@@ -139,8 +139,10 @@ function LinkForm({
 						{t(err)}
 					</p>
 				))}
-				{state?.errMessage && (
-					<p className="mt-2 text-sm text-destructive">{t(state.errMessage)}</p>
+				{state?.defaultErrMessage && (
+					<p className="mt-2 text-sm text-destructive">
+						{t(state.defaultErrMessage)}
+					</p>
 				)}
 			</div>
 

--- a/src/app/[locale]/ui/links/links-context-menu.tsx
+++ b/src/app/[locale]/ui/links/links-context-menu.tsx
@@ -99,8 +99,8 @@ function UnArchiveLink({
 				e.preventDefault();
 				const res = await unarchiveLink(id);
 
-				if (res.errMessage) {
-					toast.error(t(res.errMessage));
+				if (res.defaultErrMessage) {
+					toast.error(t(res.defaultErrMessage));
 					onUnarchiveFailed(id);
 					return;
 				}
@@ -143,8 +143,8 @@ function ArchiveLink({
 				e.preventDefault();
 				const res = await archiveLink(id);
 
-				if (res.errMessage) {
-					toast.error(t(res.errMessage));
+				if (res.defaultErrMessage) {
+					toast.error(t(res.defaultErrMessage));
 					onArchiveFailed(id);
 					return;
 				}
@@ -187,8 +187,8 @@ function DeleteLink({
 				e.preventDefault();
 				const res = await deleteLink(id);
 
-				if (res.errMessage) {
-					toast.error(t(res.errMessage));
+				if (res.defaultErrMessage) {
+					toast.error(t(res.defaultErrMessage));
 					onDeleteFailed(id);
 					return;
 				}

--- a/src/app/[locale]/ui/newsletters/add-newsletter-form.tsx
+++ b/src/app/[locale]/ui/newsletters/add-newsletter-form.tsx
@@ -112,7 +112,7 @@ function NewsletterForm({
 	const t = useTranslations("newsletter");
 	const initialState: AddNewsletterState = {
 		errors: undefined,
-		errMessage: undefined,
+		defaultErrMessage: undefined,
 		data: undefined,
 	};
 	const [state, action, pending] = useActionState(addNewsletter, initialState);
@@ -153,8 +153,10 @@ function NewsletterForm({
 					</p>
 				))}
 
-				{state?.errMessage && (
-					<p className="mt-2 text-sm text-destructive">{t(state.errMessage)}</p>
+				{state?.defaultErrMessage && (
+					<p className="mt-2 text-sm text-destructive">
+						{t(state.defaultErrMessage)}
+					</p>
 				)}
 
 				{state?.successMessage && (

--- a/src/app/[locale]/ui/newsletters/newsletter-item.tsx
+++ b/src/app/[locale]/ui/newsletters/newsletter-item.tsx
@@ -168,8 +168,8 @@ function DeleteNewsletterDialog({
 		startTransition(async () => {
 			try {
 				const res = await deleteNewsletter(feedId);
-				if (res.errMessage) {
-					toast.error(t(res.errMessage));
+				if (res.defaultErrMessage) {
+					toast.error(t(res.defaultErrMessage));
 					return;
 				}
 			} catch (_err) {

--- a/src/app/[locale]/ui/settings/settings.tsx
+++ b/src/app/[locale]/ui/settings/settings.tsx
@@ -1,26 +1,25 @@
-import { redirect } from "next/navigation";
+import type { Session } from "next-auth";
 import { useTranslations } from "next-intl";
 import { TbMail, TbUser } from "react-icons/tb";
-import { APP_ROUTES } from "@/app/[locale]/lib/constants";
 import { ViewSection } from "@/app/[locale]/ui/settings/view/view-section";
 import { SPACING } from "@/app/[locale]/ui/spacing";
-import { auth } from "@/auth";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { cn } from "@/lib/utils";
 
-export async function Settings(): Promise<React.JSX.Element> {
-	const user = await auth();
-	if (!user) return redirect(APP_ROUTES.login);
+type Props = {
+	user: Session["user"];
+};
 
+export async function Settings({ user }: Props): Promise<React.JSX.Element> {
 	return (
 		<section>
-			<ProfileSection
-				name={user.user.name ?? ""}
-				email={user.user.email ?? ""}
+			<ProfileSection name={user.name ?? ""} email={user.email ?? ""} />
+			<ViewSection
+				userPreferences={user.preferences}
+				feedContentLimit={user.feedContentLimit}
 			/>
-			<ViewSection feedContentLimit={user.user.feedContentLimit} />
 			<ExportDataSection />
 			<DeleteAccountSection />
 		</section>

--- a/src/app/[locale]/ui/settings/settings.tsx
+++ b/src/app/[locale]/ui/settings/settings.tsx
@@ -16,10 +16,7 @@ export async function Settings({ user }: Props): Promise<React.JSX.Element> {
 	return (
 		<section>
 			<ProfileSection name={user.name ?? ""} email={user.email ?? ""} />
-			<ViewSection
-				userPreferences={user.preferences}
-				feedContentLimit={user.feedContentLimit}
-			/>
+			<ViewSection userPreferences={user.preferences} />
 			<ExportDataSection />
 			<DeleteAccountSection />
 		</section>

--- a/src/app/[locale]/ui/settings/settings.tsx
+++ b/src/app/[locale]/ui/settings/settings.tsx
@@ -12,7 +12,7 @@ type Props = {
 	user: Session["user"];
 };
 
-export async function Settings({ user }: Props): Promise<React.JSX.Element> {
+export function Settings({ user }: Props): React.JSX.Element {
 	return (
 		<section>
 			<ProfileSection name={user.name ?? ""} email={user.email ?? ""} />

--- a/src/app/[locale]/ui/settings/view/view-section.tsx
+++ b/src/app/[locale]/ui/settings/view/view-section.tsx
@@ -2,7 +2,12 @@
 import { useTranslations } from "next-intl";
 import { startTransition, useOptimistic } from "react";
 import { toast } from "sonner";
-import { setFeedContentLimit } from "@/app/[locale]/lib/actions";
+import {
+	setFeedContentLimit,
+	setHideReadFeedContent,
+} from "@/app/[locale]/lib/actions";
+import type { UserPreferences } from "@/app/[locale]/lib/constants";
+import { logger } from "@/app/[locale]/lib/logging";
 import { SPACING } from "@/app/[locale]/ui/spacing";
 import { Label } from "@/components/ui/label";
 import {
@@ -12,25 +17,41 @@ import {
 	SelectTrigger,
 	SelectValue,
 } from "@/components/ui/select";
+import { Switch } from "@/components/ui/switch";
 import { cn } from "@/lib/utils";
+
+type Props = {
+	feedContentLimit: number;
+	userPreferences: UserPreferences;
+};
 
 export function ViewSection({
 	feedContentLimit,
-}: {
-	feedContentLimit: number;
-}): React.JSX.Element {
+	userPreferences,
+}: Props): React.JSX.Element {
 	const t = useTranslations("settings.viewSection");
 
 	return (
 		<section className={cn("mb-12", SPACING.LG)}>
 			<h1 className="text-xl font-medium">{t("title")}</h1>
 
-			<FeedContentLimitForm feedContentLimit={feedContentLimit} />
+			<Group>
+				<FeedContentLimitForm feedContentLimit={feedContentLimit} />
+				<HideReadFeedContentForm
+					hideReadFeedContent={userPreferences.hideReadFeedContent}
+				/>
+			</Group>
 		</section>
 	);
 }
 
-export function FeedContentLimitForm({
+function Group({ children }: { children: React.ReactNode }): React.JSX.Element {
+	return (
+		<div className={cn("border rounded-md p-4", SPACING.LG)}>{children}</div>
+	);
+}
+
+function FeedContentLimitForm({
 	feedContentLimit,
 }: {
 	feedContentLimit: number;
@@ -43,7 +64,6 @@ export function FeedContentLimitForm({
 				setValue(Number.parseInt(e));
 				toast.success(t("success"));
 				const res = await setFeedContentLimit(e);
-
 				if (res.errors?.feedContentLimit) {
 					setValue(feedContentLimit);
 					for (const error of res.errors.feedContentLimit) {
@@ -52,13 +72,14 @@ export function FeedContentLimitForm({
 					return;
 				}
 
-				if (res.errMessage) {
+				if (res.defaultErrMessage) {
 					setValue(feedContentLimit);
-					toast.error(t(res.errMessage));
+					toast.error(t(res.defaultErrMessage));
 					return;
 				}
-			} catch (_err) {
+			} catch (err) {
 				setValue(feedContentLimit);
+				logger.error(err);
 				toast.error(t("errors.unexpected"));
 			}
 		});
@@ -67,7 +88,7 @@ export function FeedContentLimitForm({
 	const t = useTranslations("settings.viewSection");
 
 	return (
-		<div className="flex items-center justify-between gap-4 border rounded-md p-4">
+		<div className="flex justify-between items-center gap-4">
 			<div className={SPACING.XS}>
 				<Label className="font-bold text-base" htmlFor="feed-limit">
 					{t("feed.title")}
@@ -107,6 +128,59 @@ export function FeedContentLimitForm({
 					<SelectItem value="100">100</SelectItem>
 				</SelectContent>
 			</Select>
+		</div>
+	);
+}
+
+function HideReadFeedContentForm({
+	hideReadFeedContent,
+}: {
+	hideReadFeedContent: boolean;
+}): React.JSX.Element {
+	const t = useTranslations("settings.viewSection");
+	const [value, setValue] = useOptimistic(hideReadFeedContent);
+
+	const handleCheckedChange = (checked: boolean) => {
+		startTransition(async () => {
+			try {
+				setValue(checked);
+				toast.success(t("success"));
+				const res = await setHideReadFeedContent(checked);
+				if (res.errors?.hideRead) {
+					setValue(hideReadFeedContent);
+					for (const error of res.errors.hideRead) {
+						toast.error(t(error));
+					}
+					return;
+				}
+
+				if (res.defaultErrMessage) {
+					setValue(hideReadFeedContent);
+					toast.error(t(res.defaultErrMessage));
+					return;
+				}
+			} catch (err) {
+				logger.error(err);
+				setValue(hideReadFeedContent);
+				toast.error(err?.toString() ?? t("errors.unexpected"));
+			}
+		});
+	};
+
+	return (
+		<div className="flex justify-between items-center gap-4">
+			<div className={SPACING.XS}>
+				<Label className="font-bold text-base" htmlFor="hide-switch">
+					{t("hide.title")}
+				</Label>
+				<p className="text-sm text-muted-foreground">{t("hide.description")}</p>
+			</div>
+
+			<Switch
+				id="hide-switch"
+				checked={value}
+				onCheckedChange={handleCheckedChange}
+			/>
 		</div>
 	);
 }

--- a/src/app/[locale]/ui/settings/view/view-section.tsx
+++ b/src/app/[locale]/ui/settings/view/view-section.tsx
@@ -21,14 +21,10 @@ import { Switch } from "@/components/ui/switch";
 import { cn } from "@/lib/utils";
 
 type Props = {
-	feedContentLimit: number;
 	userPreferences: UserPreferences;
 };
 
-export function ViewSection({
-	feedContentLimit,
-	userPreferences,
-}: Props): React.JSX.Element {
+export function ViewSection({ userPreferences }: Props): React.JSX.Element {
 	const t = useTranslations("settings.viewSection");
 
 	return (
@@ -36,7 +32,9 @@ export function ViewSection({
 			<h1 className="text-xl font-medium">{t("title")}</h1>
 
 			<Group>
-				<FeedContentLimitForm feedContentLimit={feedContentLimit} />
+				<FeedContentLimitForm
+					feedContentLimit={userPreferences.feedContentLimit}
+				/>
 				<HideReadFeedContentForm
 					hideReadFeedContent={userPreferences.hideReadFeedContent}
 				/>

--- a/src/app/[locale]/ui/settings/view/view-section.tsx
+++ b/src/app/[locale]/ui/settings/view/view-section.tsx
@@ -61,7 +61,7 @@ function FeedContentLimitForm({
 			try {
 				setValue(Number.parseInt(e));
 				toast.success(t("success"));
-				const res = await setFeedContentLimit(e);
+				const res = await setFeedContentLimit(Number.parseInt(e));
 				if (res.errors?.feedContentLimit) {
 					setValue(feedContentLimit);
 					for (const error of res.errors.feedContentLimit) {

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -52,13 +52,14 @@ const config = {
 			});
 
 			// In case some users don't have preferences yet (created before this feature).
-			const finalPrefrences = {
+			// So we need to have default preferences
+			const finalPreferences = {
 				...DEFAULT_USERS_PREFERENCES,
 				...userPrefs?.prefs,
 			};
 
 			session.user.id = user.id;
-			session.user.preferences = finalPrefrences;
+			session.user.preferences = finalPreferences;
 			return session;
 		},
 	},

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -25,7 +25,6 @@ declare module "next-auth" {
 	interface Session {
 		user: {
 			id: string;
-			feedContentLimit: number;
 			preferences: typeof DEFAULT_USERS_PREFERENCES;
 		} & DefaultSession["user"];
 	}
@@ -72,7 +71,10 @@ const config = {
 					prefs: DEFAULT_USERS_PREFERENCES,
 				});
 			} else {
-				logger.warn("User ID is not defined in auth.ts > createUser", user);
+				logger.error(
+					"User ID is somehow not defined in auth.ts > createUser",
+					user,
+				);
 			}
 		},
 	},

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -3,6 +3,7 @@ import {
 	boolean,
 	check,
 	integer,
+	jsonb,
 	pgTable,
 	primaryKey,
 	text,
@@ -14,6 +15,7 @@ import { createSchemaFactory } from "drizzle-zod";
 import type { AdapterAccountType } from "next-auth/adapters";
 import { z } from "zod/v4";
 import {
+	type DEFAULT_USERS_PREFERENCES,
 	FeedErrorType,
 	FeedStatusType,
 	LENGTHS,
@@ -50,6 +52,17 @@ export const users = pgTable(
 		),
 	],
 );
+
+/**
+ * usersPreferences contains users preferences.
+ */
+export const usersPreferences = pgTable("users_preferences", {
+	userId: text()
+		.notNull()
+		.primaryKey()
+		.references(() => users.id, { onDelete: "cascade" }),
+	prefs: jsonb().notNull().$type<typeof DEFAULT_USERS_PREFERENCES>(),
+});
 
 /**
  * links contains links that a user has saved.

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -1,7 +1,6 @@
-import { type InferSelectModel, sql } from "drizzle-orm";
+import type { InferSelectModel } from "drizzle-orm";
 import {
 	boolean,
-	check,
 	integer,
 	jsonb,
 	pgTable,
@@ -18,7 +17,6 @@ import {
 	type DEFAULT_USERS_PREFERENCES,
 	FeedErrorType,
 	FeedStatusType,
-	LENGTHS,
 } from "@/app/[locale]/lib/constants";
 
 // biome-ignore lint/suspicious/noExplicitAny: locale exception.
@@ -43,14 +41,13 @@ export const users = pgTable(
 		email: text().unique(),
 		emailVerified: timestamp({ mode: "date" }),
 		image: text(),
-		feedContentLimit: integer().default(10).notNull(),
 	},
-	(table) => [
-		check(
-			"feedContentLimit_check",
-			sql`${table.feedContentLimit} > 0 AND ${table.feedContentLimit} <= 100`,
-		),
-	],
+	// (table) => [
+	// 	check(
+	// 		"feedContentLimit_check",
+	// 		sql`${table.feedContentLimit} > 0 AND ${table.feedContentLimit} <= 100`,
+	// 	),
+	// ],
 );
 
 /**
@@ -240,17 +237,6 @@ export const authenticators = pgTable(
 		}),
 	],
 );
-
-export const insertUsersSchema = createInsertSchema(users, {
-	feedContentLimit: (schema): z.ZodCoercedNumber =>
-		schema
-			.gt(0, {
-				error: "errors.feedContentLimitFieldInvalid",
-			})
-			.lte(LENGTHS.feeds.maxPerUser, {
-				error: "errors.feedContentLimitFieldInvalid",
-			}),
-}).pick({ feedContentLimit: true });
 
 export const insertLinksSchema = createInsertSchema(links, {
 	url: (): z.ZodCoercedString =>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced user preferences management, allowing users to customize settings such as hiding read feed content and adjusting feed content limits.
  * Added support for storing user preferences in a dedicated preferences section.

* **Improvements**
  * Settings and feeds timeline now respect user preferences for content display and visibility.
  * Enhanced settings page with new options for hiding read feed content and adjusting feed content limits.
  * Session handling updated to include user preferences for a more personalized experience.
  * Error message handling standardized across forms and context menus for consistency.
  * Settings page refactored to receive authenticated user data as props, simplifying authentication flow.

* **Bug Fixes**
  * Improved error handling and messaging throughout forms and context menus.

* **Localization**
  * Updated English and French translations to reflect new settings options and error messages.

* **Database Changes**
  * Migrated user-specific settings to a new preferences table for improved flexibility and scalability.
  * Removed obsolete feed content limit column from user profiles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->