### PR TITLE
refactor: retirer `handleOnRemoveFailed()` puique `useOptimistic()` r…

### DIFF
--- a/src/app/[locale]/ui/feeds/sidebar/feeds-sidebar-content.tsx
+++ b/src/app/[locale]/ui/feeds/sidebar/feeds-sidebar-content.tsx
@@ -96,18 +96,6 @@ export function FeedsSidebarContent({
 		});
 	};
 
-	// Optimistic delete.
-	// Si la suppression ne fonctionne pas, remettre l'id à son ancienne valeur,
-	// en remettant la snapshot.
-	const handleOnRemoveFailed = (_id: number) => {
-		startTransition(() => {
-			// Trouver le dossier.
-			const snapshot = rollbackSnapshotRef.current;
-			if (!snapshot) return;
-			return setUserFeedsGroupedByFolder(() => structuredClone(snapshot));
-		});
-	};
-
 	return (
 		<DragDropProvider
 			// biome-ignore lint/suspicious/noTsIgnore: valid type.
@@ -165,7 +153,6 @@ export function FeedsSidebarContent({
 			<Content
 				userFeedsGroupedByFolder={userFeedsGroupedByFolder}
 				handleOnRemove={handleOnRemove}
-				handleOnRemoveFailed={handleOnRemoveFailed}
 			/>
 		</DragDropProvider>
 	);
@@ -176,11 +163,9 @@ export function FeedsSidebarContent({
 function Content({
 	userFeedsGroupedByFolder,
 	handleOnRemove,
-	handleOnRemoveFailed,
 }: {
 	userFeedsGroupedByFolder: FeedFolder[];
 	handleOnRemove: (id: number) => void;
-	handleOnRemoveFailed: (id: number) => void;
 }) {
 	const t = useTranslations("rssFeed");
 
@@ -226,9 +211,6 @@ function Content({
 									folder={folder}
 									onRemove={(id) => {
 										handleOnRemove(id);
-									}}
-									onRemoveFailed={(id) => {
-										handleOnRemoveFailed(id);
 									}}
 								/>
 							);

--- a/src/app/[locale]/ui/feeds/sidebar/feeds-sidebar-folder.tsx
+++ b/src/app/[locale]/ui/feeds/sidebar/feeds-sidebar-folder.tsx
@@ -44,14 +44,9 @@ import { searchParamsState } from "@/lib/stores/search-params-states";
 type Props = {
 	folder: FeedFolder;
 	onRemove: (id: number) => void;
-	onRemoveFailed: (id: number) => void;
 };
 
-export function FeedsSidebarFolder({
-	folder,
-	onRemove,
-	onRemoveFailed,
-}: Props) {
+export function FeedsSidebarFolder({ folder, onRemove }: Props) {
 	const { ref, isDropTarget } = useDroppable({
 		id: folder.folderId,
 	});
@@ -90,11 +85,7 @@ export function FeedsSidebarFolder({
 						align={isMobile ? "end" : "start"}
 					>
 						<DropdownMenuItem variant="destructive">
-							<DeleteFolder
-								onDelete={onRemove}
-								onDeleteFailed={onRemoveFailed}
-								id={folder.folderId}
-							/>
+							<DeleteFolder onDelete={onRemove} id={folder.folderId} />
 						</DropdownMenuItem>
 					</DropdownMenuContent>
 				</DropdownMenu>
@@ -200,11 +191,9 @@ function ItemIcon({
 function DeleteFolder({
 	id,
 	onDelete,
-	onDeleteFailed,
 }: {
 	id: number;
 	onDelete: (id: number) => void;
-	onDeleteFailed: (id: number) => void;
 }): React.JSX.Element {
 	const t = useTranslations("rssFeed");
 	const [isPending, startTransition] = useTransition();
@@ -217,19 +206,16 @@ function DeleteFolder({
 				const res = await deleteFeedFolder(id);
 
 				if (res.errors) {
-					onDeleteFailed(id);
 					toast.error(res.errors.id?.join(", "));
 					return;
 				}
 
 				if (res.errI18Key) {
-					onDeleteFailed(id);
 					// biome-ignore lint/suspicious/noExplicitAny: valid type.
 					toast.error(t(res.errI18Key as any));
 					return;
 				}
 			} catch (err) {
-				onDeleteFailed(id);
 				if (err instanceof Error) {
 					toast.error(err.message);
 				} else {


### PR DESCRIPTION
…etroune à l'état initial en cas d'erreur.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified error handling logic for folder removal in the feeds sidebar.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->