### PR TITLE
feat: afficher le nombre de contenu non lus dans la barre latérale dans /feeds

### DIFF
--- a/.zed/debug.json
+++ b/.zed/debug.json
@@ -1,0 +1,5 @@
+// Project-local debug tasks
+//
+// For more documentation on how to configure debug tasks,
+// see: https://zed.dev/docs/debugger
+[]

--- a/next.config.ts
+++ b/next.config.ts
@@ -14,9 +14,7 @@ const nextConfig: NextConfig = {
   },
 
   reactCompiler: true,
-
   cacheComponents: true,
-
   experimental: {
     // Forward browser logs to the terminal for easier debugging
     browserDebugInfoInTerminal: true,

--- a/src/app/[locale]/(app)/d/(sidebar)/feeds/layout.tsx
+++ b/src/app/[locale]/(app)/d/(sidebar)/feeds/layout.tsx
@@ -1,7 +1,7 @@
 import { AppNavigationMenu } from "@/app/[locale]/ui/app-navigation-menu";
 import { FeedsSidebar } from "@/app/[locale]/ui/feeds/sidebar/feeds-sidebar";
 import { SidebarFeedsProvider } from "@/components/ui/sidebar";
-import FeedsReadCountProvider from "@/lib/stores/feeds-read-count-context";
+import FeedsUnreadCountProvider from "@/lib/stores/feeds-read-count-context";
 
 export default function DashboardLayout({
 	children,
@@ -10,13 +10,13 @@ export default function DashboardLayout({
 }): React.JSX.Element {
 	return (
 		<SidebarFeedsProvider>
-			<FeedsReadCountProvider>
+			<FeedsUnreadCountProvider>
 				<FeedsSidebar />
 				<div className="min-h-screen w-full max-w-6xl mx-auto px-4 mb-12 peer-data-[state=expanded]:px-10">
 					<AppNavigationMenu />
 					<main>{children}</main>
 				</div>
-			</FeedsReadCountProvider>
+			</FeedsUnreadCountProvider>
 		</SidebarFeedsProvider>
 	);
 }

--- a/src/app/[locale]/(app)/d/(sidebar)/feeds/layout.tsx
+++ b/src/app/[locale]/(app)/d/(sidebar)/feeds/layout.tsx
@@ -1,6 +1,7 @@
 import { AppNavigationMenu } from "@/app/[locale]/ui/app-navigation-menu";
 import { FeedsSidebar } from "@/app/[locale]/ui/feeds/sidebar/feeds-sidebar";
 import { SidebarFeedsProvider } from "@/components/ui/sidebar";
+import FeedsReadCountProvider from "@/lib/stores/feeds-read-count-context";
 
 export default function DashboardLayout({
 	children,
@@ -9,11 +10,13 @@ export default function DashboardLayout({
 }): React.JSX.Element {
 	return (
 		<SidebarFeedsProvider>
-			<FeedsSidebar />
-			<div className="min-h-screen w-full max-w-6xl mx-auto px-4 mb-12 peer-data-[state=expanded]:px-10">
-				<AppNavigationMenu />
-				<main>{children}</main>
-			</div>
+			<FeedsReadCountProvider>
+				<FeedsSidebar />
+				<div className="min-h-screen w-full max-w-6xl mx-auto px-4 mb-12 peer-data-[state=expanded]:px-10">
+					<AppNavigationMenu />
+					<main>{children}</main>
+				</div>
+			</FeedsReadCountProvider>
 		</SidebarFeedsProvider>
 	);
 }

--- a/src/app/[locale]/ui/feeds/feeds-timeline.tsx
+++ b/src/app/[locale]/ui/feeds/feeds-timeline.tsx
@@ -64,28 +64,29 @@ const Item = ({ item }: { item: FeedTimeline }): React.JSX.Element => {
 	): Promise<void> => {
 		startTransition(async () => {
 			try {
-				feedsReadCount.updateReadCount(feedId, -1);
+				feedsReadCount.updateDelta(feedId, -1);
 				setIsRead(true);
 				const res = await markFeedContentAsRead(feedId, feedContentId);
 
 				if (res.errors) {
-					feedsReadCount.updateReadCount(feedId, +1);
+					feedsReadCount.updateDelta(feedId, +1);
 					setIsRead(false);
 					toast.error([res.errors.feedId, res.errors.feedContentId].join(", "));
 					return;
 				}
 
 				if (res.errI18Key) {
-					feedsReadCount.updateReadCount(feedId, +1);
+					feedsReadCount.updateDelta(feedId, +1);
 					setIsRead(false);
 					// biome-ignore lint/suspicious/noExplicitAny: valid type.
 					toast.error(t(res.errI18Key as any));
 					return;
 				}
 
-				feedsReadCount.resetReadCount(feedId);
+				// Ensure no double substract.
+				feedsReadCount.resetDelta(feedId);
 			} catch (err) {
-				feedsReadCount.updateReadCount(feedId, +1);
+				feedsReadCount.updateDelta(feedId, +1);
 				setIsRead(false);
 				if (err instanceof Error) {
 					toast.error(err.message);
@@ -102,28 +103,28 @@ const Item = ({ item }: { item: FeedTimeline }): React.JSX.Element => {
 	): Promise<void> => {
 		startTransition(async () => {
 			try {
-				feedsReadCount.updateReadCount(feedId, +1);
+				feedsReadCount.updateDelta(feedId, +1);
 				setIsRead(false);
 				const res = await markFeedContentAsUnread(feedId, feedContentId);
 
 				if (res.errors) {
-					feedsReadCount.updateReadCount(feedId, -1);
+					feedsReadCount.updateDelta(feedId, -1);
 					setIsRead(true);
 					toast.error([res.errors.feedId, res.errors.feedContentId].join(", "));
 					return;
 				}
 
 				if (res.errI18Key) {
-					feedsReadCount.updateReadCount(feedId, -1);
+					feedsReadCount.updateDelta(feedId, -1);
 					setIsRead(true);
 					// biome-ignore lint/suspicious/noExplicitAny: valid type.
 					toast.error(t(res.errI18Key as any));
 					return;
 				}
 
-				feedsReadCount.resetReadCount(feedId);
+				feedsReadCount.resetDelta(feedId);
 			} catch (err) {
-				feedsReadCount.updateReadCount(feedId, -1);
+				feedsReadCount.updateDelta(feedId, -1);
 				setIsRead(true);
 				if (err instanceof Error) {
 					toast.error(err.message);

--- a/src/app/[locale]/ui/feeds/feeds-timeline.tsx
+++ b/src/app/[locale]/ui/feeds/feeds-timeline.tsx
@@ -119,7 +119,7 @@ const Item = ({ item }: { item: FeedTimeline }): React.JSX.Element => {
 					return;
 				}
 			} catch (err) {
-				feedsReadCount.updateReadCount(feedId, +1);
+				feedsReadCount.updateReadCount(feedId, -1);
 				setIsRead(true);
 				if (err instanceof Error) {
 					toast.error(err.message);

--- a/src/app/[locale]/ui/feeds/feeds-timeline.tsx
+++ b/src/app/[locale]/ui/feeds/feeds-timeline.tsx
@@ -82,6 +82,8 @@ const Item = ({ item }: { item: FeedTimeline }): React.JSX.Element => {
 					toast.error(t(res.errI18Key as any));
 					return;
 				}
+
+				feedsReadCount.resetReadCount(feedId);
 			} catch (err) {
 				feedsReadCount.updateReadCount(feedId, +1);
 				setIsRead(false);
@@ -118,6 +120,8 @@ const Item = ({ item }: { item: FeedTimeline }): React.JSX.Element => {
 					toast.error(t(res.errI18Key as any));
 					return;
 				}
+
+				feedsReadCount.resetReadCount(feedId);
 			} catch (err) {
 				feedsReadCount.updateReadCount(feedId, -1);
 				setIsRead(true);

--- a/src/app/[locale]/ui/feeds/feeds-timeline.tsx
+++ b/src/app/[locale]/ui/feeds/feeds-timeline.tsx
@@ -12,6 +12,7 @@ import { Link } from "@/i18n/routing";
 import { markFeedContentAsRead, markFeedContentAsUnread } from "@/lib/actions";
 import type { UserPreferences } from "@/lib/constants";
 import { parsing } from "@/lib/parsing.client";
+import { useFeedsReadCount } from "@/lib/stores/feeds-read-count-context";
 import { searchParamsState } from "@/lib/stores/search-params-states";
 import { userfeedsfuncs } from "@/lib/userfeeds-funcs";
 import { cn } from "@/lib/utils";
@@ -55,6 +56,7 @@ const Item = ({ item }: { item: FeedTimeline }): React.JSX.Element => {
 	const locale = useLocale();
 
 	const [isRead, setIsRead] = useOptimistic(item.readAt !== null);
+	const feedsReadCount = useFeedsReadCount();
 
 	const handleMarkAsRead = async (
 		feedId: number,
@@ -62,22 +64,26 @@ const Item = ({ item }: { item: FeedTimeline }): React.JSX.Element => {
 	): Promise<void> => {
 		startTransition(async () => {
 			try {
+				feedsReadCount.updateReadCount(feedId, -1);
 				setIsRead(true);
 				const res = await markFeedContentAsRead(feedId, feedContentId);
 
 				if (res.errors) {
+					feedsReadCount.updateReadCount(feedId, +1);
 					setIsRead(false);
 					toast.error([res.errors.feedId, res.errors.feedContentId].join(", "));
 					return;
 				}
 
 				if (res.errI18Key) {
+					feedsReadCount.updateReadCount(feedId, +1);
 					setIsRead(false);
 					// biome-ignore lint/suspicious/noExplicitAny: valid type.
 					toast.error(t(res.errI18Key as any));
 					return;
 				}
 			} catch (err) {
+				feedsReadCount.updateReadCount(feedId, +1);
 				setIsRead(false);
 				if (err instanceof Error) {
 					toast.error(err.message);
@@ -94,22 +100,26 @@ const Item = ({ item }: { item: FeedTimeline }): React.JSX.Element => {
 	): Promise<void> => {
 		startTransition(async () => {
 			try {
+				feedsReadCount.updateReadCount(feedId, +1);
 				setIsRead(false);
 				const res = await markFeedContentAsUnread(feedId, feedContentId);
 
 				if (res.errors) {
+					feedsReadCount.updateReadCount(feedId, -1);
 					setIsRead(true);
 					toast.error([res.errors.feedId, res.errors.feedContentId].join(", "));
 					return;
 				}
 
 				if (res.errI18Key) {
+					feedsReadCount.updateReadCount(feedId, -1);
 					setIsRead(true);
 					// biome-ignore lint/suspicious/noExplicitAny: valid type.
 					toast.error(t(res.errI18Key as any));
 					return;
 				}
 			} catch (err) {
+				feedsReadCount.updateReadCount(feedId, +1);
 				setIsRead(true);
 				if (err instanceof Error) {
 					toast.error(err.message);

--- a/src/app/[locale]/ui/feeds/feeds-timeline.tsx
+++ b/src/app/[locale]/ui/feeds/feeds-timeline.tsx
@@ -84,10 +84,6 @@ const Item = ({
 	const [isRead, setIsRead] = useOptimistic(item.readAt !== null);
 	const feedsReadCount = useFeedsUnereadCount();
 
-	const wait = async (ms: number) => {
-		await new Promise((resolve) => setTimeout(resolve, ms));
-	};
-
 	const handleMarkAsRead = async (
 		feedId: number,
 		feedContentId: number,
@@ -101,11 +97,7 @@ const Item = ({
 		startTransition(async () => {
 			try {
 				setIsRead(true);
-				await wait(2000);
 				const res = await markFeedContentAsRead(feedId, feedContentId);
-				// Prevent double subtraction.
-				feedsReadCount.clearOptimistic(feedId);
-				// await wait(2000);
 
 				if (res.errors) {
 					feedsReadCount.setOptimisticUnread(
@@ -159,7 +151,6 @@ const Item = ({
 				setIsRead(false);
 				const res = await markFeedContentAsUnread(feedId, feedContentId);
 				// Prevent double subtraction.
-				feedsReadCount.clearOptimistic(feedId);
 
 				if (res.errors) {
 					feedsReadCount.setOptimisticUnread(

--- a/src/app/[locale]/ui/feeds/feeds-timeline.tsx
+++ b/src/app/[locale]/ui/feeds/feeds-timeline.tsx
@@ -12,7 +12,7 @@ import { Link } from "@/i18n/routing";
 import { markFeedContentAsRead, markFeedContentAsUnread } from "@/lib/actions";
 import type { UserPreferences } from "@/lib/constants";
 import { parsing } from "@/lib/parsing.client";
-import { useFeedsReadCount } from "@/lib/stores/feeds-read-count-context";
+import { useFeedsUnereadCount } from "@/lib/stores/feeds-read-count-context";
 import { searchParamsState } from "@/lib/stores/search-params-states";
 import { userfeedsfuncs } from "@/lib/userfeeds-funcs";
 import { cn } from "@/lib/utils";
@@ -30,6 +30,16 @@ export function FeedsTimeline({
 		urlKeys: searchParamsState.urlKeys,
 	});
 
+	const feedUnreadCounts: Map<number, number> = new Map();
+	for (const item of timeline) {
+		if (item.readAt === null) {
+			feedUnreadCounts.set(
+				item.feedId,
+				(feedUnreadCounts.get(item.feedId) ?? 0) + 1,
+			);
+		}
+	}
+
 	const items = timeline
 		.filter((el) => {
 			if (selectedFeed === searchParamsState.DEFAULT_FEED) return true;
@@ -45,48 +55,86 @@ export function FeedsTimeline({
 	return (
 		<section className={cn("wrap-anywhere", SPACING.LG)}>
 			{items.map((item) => {
-				return <Item item={item} key={`${item.id}`} />;
+				return (
+					<Item
+						item={item}
+						feedUnreadCounts={feedUnreadCounts.get(item.feedId) ?? 0}
+						key={`${item.id}`}
+					/>
+				);
 			})}
 		</section>
 	);
 }
 
-const Item = ({ item }: { item: FeedTimeline }): React.JSX.Element => {
+const Item = ({
+	item,
+	feedUnreadCounts,
+}: {
+	item: FeedTimeline;
+	/**
+	 * feedUnreadCounts is the initial number of items left to read in a feed.
+	 * Used for optimistic updates to sync with the sidebar through the context.
+	 */
+	feedUnreadCounts: number;
+}): React.JSX.Element => {
 	const t = useTranslations("rssFeed");
 	const locale = useLocale();
 
 	const [isRead, setIsRead] = useOptimistic(item.readAt !== null);
-	const feedsReadCount = useFeedsReadCount();
+	const feedsReadCount = useFeedsUnereadCount();
+
+	const wait = async (ms: number) => {
+		await new Promise((resolve) => setTimeout(resolve, ms));
+	};
 
 	const handleMarkAsRead = async (
 		feedId: number,
 		feedContentId: number,
 	): Promise<void> => {
+		feedsReadCount.setOptimisticUnread(
+			feedId,
+			feedUnreadCounts - 1,
+			feedUnreadCounts,
+		);
+
 		startTransition(async () => {
 			try {
-				feedsReadCount.updateDelta(feedId, -1);
 				setIsRead(true);
+				await wait(2000);
 				const res = await markFeedContentAsRead(feedId, feedContentId);
+				// Prevent double subtraction.
+				feedsReadCount.clearOptimistic(feedId);
+				// await wait(2000);
 
 				if (res.errors) {
-					feedsReadCount.updateDelta(feedId, +1);
+					feedsReadCount.setOptimisticUnread(
+						feedId,
+						feedUnreadCounts + 1,
+						feedUnreadCounts,
+					);
 					setIsRead(false);
 					toast.error([res.errors.feedId, res.errors.feedContentId].join(", "));
 					return;
 				}
 
 				if (res.errI18Key) {
-					feedsReadCount.updateDelta(feedId, +1);
+					feedsReadCount.setOptimisticUnread(
+						feedId,
+						feedUnreadCounts + 1,
+						feedUnreadCounts,
+					);
 					setIsRead(false);
 					// biome-ignore lint/suspicious/noExplicitAny: valid type.
 					toast.error(t(res.errI18Key as any));
 					return;
 				}
-
-				// Ensure no double substract.
-				feedsReadCount.resetDelta(feedId);
 			} catch (err) {
-				feedsReadCount.updateDelta(feedId, +1);
+				feedsReadCount.setOptimisticUnread(
+					feedId,
+					feedUnreadCounts + 1,
+					feedUnreadCounts,
+				);
 				setIsRead(false);
 				if (err instanceof Error) {
 					toast.error(err.message);
@@ -101,30 +149,46 @@ const Item = ({ item }: { item: FeedTimeline }): React.JSX.Element => {
 		feedId: number,
 		feedContentId: number,
 	): Promise<void> => {
+		feedsReadCount.setOptimisticUnread(
+			feedId,
+			feedUnreadCounts + 1,
+			feedUnreadCounts,
+		);
 		startTransition(async () => {
 			try {
-				feedsReadCount.updateDelta(feedId, +1);
 				setIsRead(false);
 				const res = await markFeedContentAsUnread(feedId, feedContentId);
+				// Prevent double subtraction.
+				feedsReadCount.clearOptimistic(feedId);
 
 				if (res.errors) {
-					feedsReadCount.updateDelta(feedId, -1);
+					feedsReadCount.setOptimisticUnread(
+						feedId,
+						feedUnreadCounts - 1,
+						feedUnreadCounts,
+					);
 					setIsRead(true);
 					toast.error([res.errors.feedId, res.errors.feedContentId].join(", "));
 					return;
 				}
 
 				if (res.errI18Key) {
-					feedsReadCount.updateDelta(feedId, -1);
+					feedsReadCount.setOptimisticUnread(
+						feedId,
+						feedUnreadCounts - 1,
+						feedUnreadCounts,
+					);
 					setIsRead(true);
 					// biome-ignore lint/suspicious/noExplicitAny: valid type.
 					toast.error(t(res.errI18Key as any));
 					return;
 				}
-
-				feedsReadCount.resetDelta(feedId);
 			} catch (err) {
-				feedsReadCount.updateDelta(feedId, -1);
+				feedsReadCount.setOptimisticUnread(
+					feedId,
+					feedUnreadCounts - 1,
+					feedUnreadCounts,
+				);
 				setIsRead(true);
 				if (err instanceof Error) {
 					toast.error(err.message);

--- a/src/app/[locale]/ui/feeds/sidebar/feeds-sidebar-content.tsx
+++ b/src/app/[locale]/ui/feeds/sidebar/feeds-sidebar-content.tsx
@@ -21,6 +21,7 @@ import {
 	type FeedWithContentsCount,
 	UNCATEGORIZED_FEEDS_FOLDER_ID,
 } from "@/lib/constants";
+import { useFeedsReadCount } from "@/lib/stores/feeds-read-count-context";
 
 type Props = {
 	userFeedsGroupedByFolderPromise: Promise<FeedFolder[]>;
@@ -164,6 +165,7 @@ function Content({
 	handleOnRemove: (id: number) => void;
 }) {
 	const t = useTranslations("rssFeed");
+	const feedsReadCount = useFeedsReadCount();
 
 	const totalFeeds = userFeedsGroupedByFolder.values().reduce((acc, folder) => {
 		return acc + folder.feeds.length;
@@ -174,7 +176,11 @@ function Content({
 			(acc, folder) =>
 				acc +
 				folder.feeds.reduce(
-					(sacc, f) => sacc + (f.contentsCount - f.readContentsCount),
+					(sacc, f) =>
+						sacc +
+						(f.contentsCount -
+							f.readContentsCount +
+							feedsReadCount.getReadCount(f.id)),
 					0,
 				),
 			0,

--- a/src/app/[locale]/ui/feeds/sidebar/feeds-sidebar-content.tsx
+++ b/src/app/[locale]/ui/feeds/sidebar/feeds-sidebar-content.tsx
@@ -21,6 +21,7 @@ import {
 	type FeedWithContentsCount,
 	UNCATEGORIZED_FEEDS_FOLDER_ID,
 } from "@/lib/constants";
+import { useFeedsReadCount } from "@/lib/stores/feeds-read-count-context";
 
 type Props = {
 	userFeedsGroupedByFolderPromise: Promise<FeedFolder[]>;
@@ -164,21 +165,26 @@ function Content({
 	handleOnRemove: (id: number) => void;
 }) {
 	const t = useTranslations("rssFeed");
-	// const feedsReadCount = useFeedsReadCount();
+	const feedsReadCount = useFeedsReadCount();
 
 	const totalFeeds = userFeedsGroupedByFolder.values().reduce((acc, folder) => {
 		return acc + folder.feeds.length;
 	}, 0);
-	const totalFeedsContents = userFeedsGroupedByFolder.values().reduce(
-		(acc, folder) =>
-			acc +
-			folder.feeds.reduce(
-				(sacc, f) => sacc + (f.contentsCount - f.readContentsCount),
-				// + feedsReadCount.getReadCount(f.id)
-				0,
-			),
-		0,
-	);
+	const totalFeedsContents = userFeedsGroupedByFolder
+		.values()
+		.reduce(
+			(acc, folder) =>
+				acc +
+				folder.feeds.reduce(
+					(sacc, f) =>
+						sacc +
+						(f.contentsCount -
+							f.readContentsCount +
+							feedsReadCount.getDelta(f.id)),
+					0,
+				),
+			0,
+		);
 	const { ref, isDropTarget } = useDroppable({
 		id: UNCATEGORIZED_FEEDS_FOLDER_ID,
 	});

--- a/src/app/[locale]/ui/feeds/sidebar/feeds-sidebar-content.tsx
+++ b/src/app/[locale]/ui/feeds/sidebar/feeds-sidebar-content.tsx
@@ -21,7 +21,6 @@ import {
 	type FeedWithContentsCount,
 	UNCATEGORIZED_FEEDS_FOLDER_ID,
 } from "@/lib/constants";
-import { useFeedsReadCount } from "@/lib/stores/feeds-read-count-context";
 
 type Props = {
 	userFeedsGroupedByFolderPromise: Promise<FeedFolder[]>;
@@ -165,26 +164,21 @@ function Content({
 	handleOnRemove: (id: number) => void;
 }) {
 	const t = useTranslations("rssFeed");
-	const feedsReadCount = useFeedsReadCount();
+	// const feedsReadCount = useFeedsReadCount();
 
 	const totalFeeds = userFeedsGroupedByFolder.values().reduce((acc, folder) => {
 		return acc + folder.feeds.length;
 	}, 0);
-	const totalFeedsContents = userFeedsGroupedByFolder
-		.values()
-		.reduce(
-			(acc, folder) =>
-				acc +
-				folder.feeds.reduce(
-					(sacc, f) =>
-						sacc +
-						(f.contentsCount -
-							f.readContentsCount +
-							feedsReadCount.getReadCount(f.id)),
-					0,
-				),
-			0,
-		);
+	const totalFeedsContents = userFeedsGroupedByFolder.values().reduce(
+		(acc, folder) =>
+			acc +
+			folder.feeds.reduce(
+				(sacc, f) => sacc + (f.contentsCount - f.readContentsCount),
+				// + feedsReadCount.getReadCount(f.id)
+				0,
+			),
+		0,
+	);
 	const { ref, isDropTarget } = useDroppable({
 		id: UNCATEGORIZED_FEEDS_FOLDER_ID,
 	});

--- a/src/app/[locale]/ui/feeds/sidebar/feeds-sidebar-content.tsx
+++ b/src/app/[locale]/ui/feeds/sidebar/feeds-sidebar-content.tsx
@@ -172,7 +172,11 @@ function Content({
 		.values()
 		.reduce(
 			(acc, folder) =>
-				acc + folder.feeds.reduce((s, f) => s + f.contentsCount, 0),
+				acc +
+				folder.feeds.reduce(
+					(sacc, f) => sacc + (f.contentsCount - f.readContentsCount),
+					0,
+				),
 			0,
 		);
 	const { ref, isDropTarget } = useDroppable({

--- a/src/app/[locale]/ui/feeds/sidebar/feeds-sidebar-content.tsx
+++ b/src/app/[locale]/ui/feeds/sidebar/feeds-sidebar-content.tsx
@@ -21,7 +21,7 @@ import {
 	type FeedWithContentsCount,
 	UNCATEGORIZED_FEEDS_FOLDER_ID,
 } from "@/lib/constants";
-import { useFeedsReadCount } from "@/lib/stores/feeds-read-count-context";
+import { useFeedsUnereadCount } from "@/lib/stores/feeds-read-count-context";
 
 type Props = {
 	userFeedsGroupedByFolderPromise: Promise<FeedFolder[]>;
@@ -165,26 +165,26 @@ function Content({
 	handleOnRemove: (id: number) => void;
 }) {
 	const t = useTranslations("rssFeed");
-	const feedsReadCount = useFeedsReadCount();
+	const feedsReadCount = useFeedsUnereadCount();
 
 	const totalFeeds = userFeedsGroupedByFolder.values().reduce((acc, folder) => {
 		return acc + folder.feeds.length;
 	}, 0);
-	const totalFeedsContents = userFeedsGroupedByFolder
-		.values()
-		.reduce(
-			(acc, folder) =>
-				acc +
-				folder.feeds.reduce(
-					(sacc, f) =>
-						sacc +
-						(f.contentsCount -
-							f.readContentsCount +
-							feedsReadCount.getDelta(f.id)),
-					0,
-				),
-			0,
-		);
+	const totalFeedsContents = userFeedsGroupedByFolder.values().reduce(
+		(acc, folder) =>
+			acc +
+			folder.feeds.reduce(
+				(sacc, f) =>
+					sacc +
+					feedsReadCount.getUnreadCount(
+						f.id,
+						f.contentsCount - f.readContentsCount,
+					),
+				// + feedsReadCount.getDelta(f.id)
+				0,
+			),
+		0,
+	);
 	const { ref, isDropTarget } = useDroppable({
 		id: UNCATEGORIZED_FEEDS_FOLDER_ID,
 	});

--- a/src/app/[locale]/ui/feeds/sidebar/feeds-sidebar-content.tsx
+++ b/src/app/[locale]/ui/feeds/sidebar/feeds-sidebar-content.tsx
@@ -155,7 +155,7 @@ export function FeedsSidebarContent({
 }
 
 // This needs to be it's own component so it can be a droppable zone.
-// The drop mechanism wouldn't work if it's a direct descendant of the parent component.
+// The drop mechanism wouldn't work if it's directly code in the parent component.
 function Content({
 	userFeedsGroupedByFolder,
 	handleOnRemove,

--- a/src/app/[locale]/ui/feeds/sidebar/feeds-sidebar-content.tsx
+++ b/src/app/[locale]/ui/feeds/sidebar/feeds-sidebar-content.tsx
@@ -170,19 +170,15 @@ function Content({
 	const totalFeeds = userFeedsGroupedByFolder.values().reduce((acc, folder) => {
 		return acc + folder.feeds.length;
 	}, 0);
+
 	const totalFeedsContents = userFeedsGroupedByFolder.values().reduce(
 		(acc, folder) =>
 			acc +
-			folder.feeds.reduce(
-				(sacc, f) =>
-					sacc +
-					feedsReadCount.getUnreadCount(
-						f.id,
-						f.contentsCount - f.readContentsCount,
-					),
-				// + feedsReadCount.getDelta(f.id)
-				0,
-			),
+			folder.feeds.reduce((sacc, f) => {
+				const serverUnread = f.contentsCount - f.readContentsCount;
+				const resolved = feedsReadCount.getUnreadCount(f.id, serverUnread);
+				return sacc + resolved;
+			}, 0),
 		0,
 	);
 	const { ref, isDropTarget } = useDroppable({

--- a/src/app/[locale]/ui/feeds/sidebar/feeds-sidebar-content.tsx
+++ b/src/app/[locale]/ui/feeds/sidebar/feeds-sidebar-content.tsx
@@ -2,7 +2,7 @@
 import { RestrictToVerticalAxis } from "@dnd-kit/abstract/modifiers";
 import { DragDropProvider, PointerSensor, useDroppable } from "@dnd-kit/react";
 import { useTranslations } from "next-intl";
-import { startTransition, use, useOptimistic, useRef } from "react";
+import { startTransition, use, useOptimistic } from "react";
 import { toast } from "sonner";
 import { FeedsSidebarFolder } from "@/app/[locale]/ui/feeds/sidebar/feeds-sidebar-folder";
 import { FeedsSidebarItem } from "@/app/[locale]/ui/feeds/sidebar/feeds-sidebar-item";
@@ -34,7 +34,6 @@ export function FeedsSidebarContent({
 		FeedFolder[]
 	>(_userFeedsGroupedByFolder);
 	// Sauvegarder les éléments au cas si optimistic delete ne fonctionne pas.
-	const rollbackSnapshotRef = useRef<FeedFolder[] | null>(null);
 	const t = useTranslations("rssFeed");
 
 	const handleOnMove = (
@@ -81,9 +80,6 @@ export function FeedsSidebarContent({
 			// Trouver le dossier orignal, puis mettre id par défaut (-1).
 			setUserFeedsGroupedByFolder((prev) => {
 				const folders: FeedFolder[] = structuredClone(prev);
-				// Sauvegarder les éléments au cas si optimistic delete ne fonctionne pas.
-				rollbackSnapshotRef.current = folders;
-
 				// Trouver le dossier.
 				const deletedFolder = folders.find((item) => item.folderId === id);
 				if (!deletedFolder) return prev;

--- a/src/app/[locale]/ui/feeds/sidebar/feeds-sidebar-folder.tsx
+++ b/src/app/[locale]/ui/feeds/sidebar/feeds-sidebar-folder.tsx
@@ -141,7 +141,9 @@ function Draggable({ feed }: { feed: FeedWithContentsCount }) {
 						isDragging={isDragging}
 					/>
 					<span className="truncate">{feed.title}</span>
-					<SidebarMenuBadge>{feed.contentsCount}</SidebarMenuBadge>
+					<SidebarMenuBadge>
+						{feed.contentsCount - feed.readContentsCount}
+					</SidebarMenuBadge>
 				</button>
 			</SidebarMenuSubButton>
 		</SidebarMenuItem>

--- a/src/app/[locale]/ui/feeds/sidebar/feeds-sidebar-folder.tsx
+++ b/src/app/[locale]/ui/feeds/sidebar/feeds-sidebar-folder.tsx
@@ -39,6 +39,7 @@ import {
 	type FeedWithContentsCount,
 } from "@/lib/constants";
 import { useIsMobile } from "@/lib/hooks/use-mobile";
+import { useFeedsReadCount } from "@/lib/stores/feeds-read-count-context";
 import { searchParamsState } from "@/lib/stores/search-params-states";
 
 type Props = {
@@ -114,6 +115,7 @@ function Draggable({ feed }: { feed: FeedWithContentsCount }) {
 			urlKeys: searchParamsState.urlKeys,
 		},
 	);
+	const feedsReadCount = useFeedsReadCount();
 
 	return (
 		<SidebarMenuItem
@@ -142,7 +144,9 @@ function Draggable({ feed }: { feed: FeedWithContentsCount }) {
 					/>
 					<span className="truncate">{feed.title}</span>
 					<SidebarMenuBadge>
-						{feed.contentsCount - feed.readContentsCount}
+						{feed.contentsCount -
+							feed.readContentsCount +
+							feedsReadCount.getReadCount(feed.id)}
 					</SidebarMenuBadge>
 				</button>
 			</SidebarMenuSubButton>

--- a/src/app/[locale]/ui/feeds/sidebar/feeds-sidebar-folder.tsx
+++ b/src/app/[locale]/ui/feeds/sidebar/feeds-sidebar-folder.tsx
@@ -39,7 +39,7 @@ import {
 	type FeedWithContentsCount,
 } from "@/lib/constants";
 import { useIsMobile } from "@/lib/hooks/use-mobile";
-import { useFeedsReadCount } from "@/lib/stores/feeds-read-count-context";
+import { useFeedsUnereadCount } from "@/lib/stores/feeds-read-count-context";
 import { searchParamsState } from "@/lib/stores/search-params-states";
 
 type Props = {
@@ -115,7 +115,7 @@ function Draggable({ feed }: { feed: FeedWithContentsCount }) {
 			urlKeys: searchParamsState.urlKeys,
 		},
 	);
-	const feedsReadCount = useFeedsReadCount();
+	const feedsReadCount = useFeedsUnereadCount();
 
 	return (
 		<SidebarMenuItem
@@ -144,9 +144,10 @@ function Draggable({ feed }: { feed: FeedWithContentsCount }) {
 					/>
 					<span className="truncate">{feed.title}</span>
 					<SidebarMenuBadge>
-						{feed.contentsCount -
-							feed.readContentsCount +
-							feedsReadCount.getDelta(feed.id)}
+						{feedsReadCount.getUnreadCount(
+							feed.id,
+							feed.contentsCount - feed.readContentsCount,
+						)}
 					</SidebarMenuBadge>
 				</button>
 			</SidebarMenuSubButton>

--- a/src/app/[locale]/ui/feeds/sidebar/feeds-sidebar-folder.tsx
+++ b/src/app/[locale]/ui/feeds/sidebar/feeds-sidebar-folder.tsx
@@ -146,7 +146,7 @@ function Draggable({ feed }: { feed: FeedWithContentsCount }) {
 					<SidebarMenuBadge>
 						{feed.contentsCount -
 							feed.readContentsCount +
-							feedsReadCount.getReadCount(feed.id)}
+							feedsReadCount.getDelta(feed.id)}
 					</SidebarMenuBadge>
 				</button>
 			</SidebarMenuSubButton>

--- a/src/app/[locale]/ui/feeds/sidebar/feeds-sidebar-item.tsx
+++ b/src/app/[locale]/ui/feeds/sidebar/feeds-sidebar-item.tsx
@@ -62,7 +62,7 @@ export function FeedsSidebarItem({ feed }: Props) {
 					<SidebarMenuBadge>
 						{feed.contentsCount -
 							feed.readContentsCount +
-							feedsReadCount.getReadCount(feed.id)}
+							feedsReadCount.getDelta(feed.id)}
 					</SidebarMenuBadge>
 				</button>
 			</SidebarFeedsMenuButton>

--- a/src/app/[locale]/ui/feeds/sidebar/feeds-sidebar-item.tsx
+++ b/src/app/[locale]/ui/feeds/sidebar/feeds-sidebar-item.tsx
@@ -12,6 +12,7 @@ import {
 } from "@/components/ui/sidebar";
 import { FeedStatusType, type FeedWithContentsCount } from "@/lib/constants";
 import { useIsMobile } from "@/lib/hooks/use-mobile";
+import { useFeedsReadCount } from "@/lib/stores/feeds-read-count-context";
 import { searchParamsState } from "@/lib/stores/search-params-states";
 
 type Props = {
@@ -30,6 +31,7 @@ export function FeedsSidebarItem({ feed }: Props) {
 		id: feed.id,
 		data: feed,
 	});
+	const feedsReadCount = useFeedsReadCount();
 
 	return (
 		<SidebarMenuItem
@@ -58,7 +60,9 @@ export function FeedsSidebarItem({ feed }: Props) {
 					/>
 					<span className="truncate min-w-0">{feed.title}</span>
 					<SidebarMenuBadge>
-						{feed.contentsCount - feed.readContentsCount}
+						{feed.contentsCount -
+							feed.readContentsCount +
+							feedsReadCount.getReadCount(feed.id)}
 					</SidebarMenuBadge>
 				</button>
 			</SidebarFeedsMenuButton>

--- a/src/app/[locale]/ui/feeds/sidebar/feeds-sidebar-item.tsx
+++ b/src/app/[locale]/ui/feeds/sidebar/feeds-sidebar-item.tsx
@@ -12,7 +12,7 @@ import {
 } from "@/components/ui/sidebar";
 import { FeedStatusType, type FeedWithContentsCount } from "@/lib/constants";
 import { useIsMobile } from "@/lib/hooks/use-mobile";
-import { useFeedsReadCount } from "@/lib/stores/feeds-read-count-context";
+import { useFeedsUnereadCount } from "@/lib/stores/feeds-read-count-context";
 import { searchParamsState } from "@/lib/stores/search-params-states";
 
 type Props = {
@@ -31,7 +31,7 @@ export function FeedsSidebarItem({ feed }: Props) {
 		id: feed.id,
 		data: feed,
 	});
-	const feedsReadCount = useFeedsReadCount();
+	const feedsReadCount = useFeedsUnereadCount();
 
 	return (
 		<SidebarMenuItem
@@ -60,9 +60,10 @@ export function FeedsSidebarItem({ feed }: Props) {
 					/>
 					<span className="truncate min-w-0">{feed.title}</span>
 					<SidebarMenuBadge>
-						{feed.contentsCount -
-							feed.readContentsCount +
-							feedsReadCount.getDelta(feed.id)}
+						{feedsReadCount.getUnreadCount(
+							feed.id,
+							feed.contentsCount - feed.readContentsCount,
+						)}
 					</SidebarMenuBadge>
 				</button>
 			</SidebarFeedsMenuButton>

--- a/src/app/[locale]/ui/feeds/sidebar/feeds-sidebar-item.tsx
+++ b/src/app/[locale]/ui/feeds/sidebar/feeds-sidebar-item.tsx
@@ -57,7 +57,9 @@ export function FeedsSidebarItem({ feed }: Props) {
 						isDragging={isDragging}
 					/>
 					<span className="truncate min-w-0">{feed.title}</span>
-					<SidebarMenuBadge>{feed.contentsCount}</SidebarMenuBadge>
+					<SidebarMenuBadge>
+						{feed.contentsCount - feed.readContentsCount}
+					</SidebarMenuBadge>
 				</button>
 			</SidebarFeedsMenuButton>
 		</SidebarMenuItem>

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -20,7 +20,10 @@ export type FeedWithContentsCount = {
 	url: string;
 	status: FeedStatusType;
 	folderId: FolderId;
+	/** Total number of items. */
 	contentsCount: number;
+	/** Number of items that where read. */
+	readContentsCount: number;
 };
 
 export enum SortOptions {

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -22,7 +22,7 @@ export type FeedWithContentsCount = {
 	folderId: FolderId;
 	/** Total number of items. */
 	contentsCount: number;
-	/** Number of items that where read. */
+	/** Number of items that were read. */
 	readContentsCount: number;
 };
 

--- a/src/lib/dal.ts
+++ b/src/lib/dal.ts
@@ -12,6 +12,7 @@ import {
 	links,
 	usersFeeds,
 	usersFeedsFolders,
+	usersFeedsReadContent,
 } from "@/db/schema";
 import "server-only";
 import { z } from "zod/v4";
@@ -166,10 +167,15 @@ const getUserFeedsWithContentsCount = cache(
 					status: feeds.status,
 					folderId: sql<number>`COALESCE(${usersFeeds.folderId}, ${UNCATEGORIZED_FEEDS_FOLDER_ID})`,
 					contentsCount: count(feedsContent.id),
+					readContentsCount: count(usersFeedsReadContent.readAt),
 				})
 				.from(feeds)
 				.innerJoin(usersFeeds, eq(usersFeeds.feedId, feeds.id))
 				.leftJoin(feedsContent, eq(feedsContent.feedId, feeds.id))
+				.leftJoin(
+					usersFeedsReadContent,
+					eq(usersFeedsReadContent.feedContentId, feedsContent.id),
+				)
 				.where(eq(usersFeeds.userId, user.user.id))
 				.groupBy(feeds.id, usersFeeds.folderId);
 		} catch (err) {
@@ -217,10 +223,15 @@ const getUserFeedsGroupedByFolder = cache(async (): Promise<FeedFolder[]> => {
 				status: feeds.status,
 				folderId: usersFeeds.folderId,
 				contentsCount: count(feedsContent.id),
+				readContentsCount: count(usersFeedsReadContent.readAt),
 			})
 			.from(feeds)
 			.leftJoin(usersFeeds, eq(usersFeeds.feedId, feeds.id))
 			.leftJoin(feedsContent, eq(feedsContent.feedId, usersFeeds.feedId))
+			.leftJoin(
+				usersFeedsReadContent,
+				eq(usersFeedsReadContent.feedContentId, feedsContent.id),
+			)
 			.where(eq(usersFeeds.userId, user.user.id))
 			.groupBy(feeds.id, usersFeeds.folderId)
 			.orderBy(feeds.title);
@@ -251,20 +262,21 @@ const getUserFeedsGroupedByFolder = cache(async (): Promise<FeedFolder[]> => {
 		// Add feeds to map.
 		for (const feed of userFeeds) {
 			if (!feed.folderId) {
-				const uncategorized = folders.find(
+				const uncategorizedFolder = folders.find(
 					(folder) => folder.folderId === UNCATEGORIZED_FEEDS_FOLDER_ID,
 				);
-				if (!uncategorized) {
+				if (!uncategorizedFolder) {
 					throw new Error(
 						"Uncategorized folder not found. It should have been created before hand.",
 					);
 				}
-				uncategorized.feeds.push({
+				uncategorizedFolder.feeds.push({
 					id: feed.id,
 					title: feed.title,
 					url: feed.url,
 					status: feed.status,
 					contentsCount: feed.contentsCount,
+					readContentsCount: feed.readContentsCount,
 					folderId: UNCATEGORIZED_FEEDS_FOLDER_ID,
 				});
 			} else {
@@ -282,6 +294,7 @@ const getUserFeedsGroupedByFolder = cache(async (): Promise<FeedFolder[]> => {
 					url: feed.url,
 					status: feed.status,
 					contentsCount: feed.contentsCount,
+					readContentsCount: feed.readContentsCount,
 					folderId: feed.folderId,
 				});
 			}

--- a/src/lib/dal.ts
+++ b/src/lib/dal.ts
@@ -174,7 +174,10 @@ const getUserFeedsWithContentsCount = cache(
 				.leftJoin(feedsContent, eq(feedsContent.feedId, feeds.id))
 				.leftJoin(
 					usersFeedsReadContent,
-					eq(usersFeedsReadContent.feedContentId, feedsContent.id),
+					and(
+						eq(usersFeedsReadContent.feedContentId, feedsContent.id),
+						eq(usersFeedsReadContent.userId, user.user.id),
+					),
 				)
 				.where(eq(usersFeeds.userId, user.user.id))
 				.groupBy(feeds.id, usersFeeds.folderId);
@@ -230,7 +233,10 @@ const getUserFeedsGroupedByFolder = cache(async (): Promise<FeedFolder[]> => {
 			.leftJoin(feedsContent, eq(feedsContent.feedId, usersFeeds.feedId))
 			.leftJoin(
 				usersFeedsReadContent,
-				eq(usersFeedsReadContent.feedContentId, feedsContent.id),
+				and(
+					eq(usersFeedsReadContent.feedContentId, feedsContent.id),
+					eq(usersFeedsReadContent.userId, user.user.id),
+				),
 			)
 			.where(eq(usersFeeds.userId, user.user.id))
 			.groupBy(feeds.id, usersFeeds.folderId)

--- a/src/lib/dal.ts
+++ b/src/lib/dal.ts
@@ -183,7 +183,7 @@ const getUserFeedsWithContentsCount = cache(
  * getUserFeedsGroupedByFolder gets:
  *   1. All the feeds folders a user has (including empty folders), with
  *   the feeds in each of those folders.
- *   3. And the feeds that are not in a folder.
+ *   2. And the feeds that are not in a folder.
  *   In other words: feeds in folder, empty folders, feeds without a folder
  */
 const getUserFeedsGroupedByFolder = cache(async (): Promise<FeedFolder[]> => {

--- a/src/lib/stores/feeds-read-count-context.tsx
+++ b/src/lib/stores/feeds-read-count-context.tsx
@@ -9,23 +9,22 @@ type feedId = number;
 type delta = number;
 type FeedsReadCountContextType = {
 	/**
-	 * Returns the read count for a given feedId.
+	 * Returns the delta change for a given feedId.
 	 */
-	getReadCount: (feedId: feedId) => delta;
+	getDelta: (feedId: feedId) => delta;
 	/**
 	 *
 	 * @param feedId feedId
 	 * @param delta represents the change amount.
 	 *  e.g : +1, -1.
-	 * @returns
 	 */
-	updateReadCount: (feedId: feedId, delta: delta) => void;
+	updateDelta: (feedId: feedId, delta: delta) => void;
 	/**
-	 * Resets the read count for a given feedId to 0.
+	 * Resets the delata for a given feedId to 0.
 	 *
 	 * @param feedId feedId
 	 */
-	resetReadCount: (feedId: feedId) => void;
+	resetDelta: (feedId: feedId) => void;
 };
 const FeedsReadCountContext = createContext<FeedsReadCountContextType | null>(
 	null,
@@ -46,23 +45,36 @@ export default function FeedsReadCountProvider({
 }: {
 	children: React.ReactNode;
 }) {
-	const [readCount, setReadCount] = useState<Map<feedId, delta>>(new Map());
+	const [delta, setDelata] = useState<Map<feedId, delta>>(new Map());
 
-	const getReadCount = (feedId: feedId) => {
-		return readCount.get(feedId) ?? 0;
+	const getDelta = (feedId: feedId) => {
+		return delta.get(feedId) ?? 0;
 	};
 
-	const updateReadCount = (feedId: feedId, delta: number) => {
-		setReadCount((prev) => new Map(prev).set(feedId, delta));
+	const updateDelta = (feedId: feedId, delta: number) => {
+		setDelata((prev) => {
+			const current = prev.get(feedId) ?? 0;
+			const next = new Map(prev);
+			next.set(feedId, current + delta);
+			return next;
+		});
 	};
 
-	const resetReadCount = (feedId: feedId) => {
-		setReadCount((prev) => new Map(prev).set(feedId, 0));
+	// un/markFeedContentAsRead calls revalidatePath server-side.
+	// By the time the client's startTransition callback finishes, Next.js has already pushed the updated RSC payload,
+	// meaning userFeedsGroupedByFolderPromise resolves with fresh delta.
+	// Calling resetDeltas() at that point ensures the delta doesn't double-subtract from the already-updated server value.
+	const resetDelta = (feedId: feedId) => {
+		setDelata((prev) => new Map(prev).set(feedId, 0));
 	};
 
 	return (
 		<FeedsReadCountContext.Provider
-			value={{ getReadCount, updateReadCount, resetReadCount }}
+			value={{
+				getDelta,
+				updateDelta,
+				resetDelta,
+			}}
 		>
 			{children}
 		</FeedsReadCountContext.Provider>

--- a/src/lib/stores/feeds-read-count-context.tsx
+++ b/src/lib/stores/feeds-read-count-context.tsx
@@ -1,36 +1,22 @@
 "use client";
+
 import { createContext, useContext, useState } from "react";
 
 type feedId = number;
-/**
- * delta represents the change amount.
- * e.g : +1, -1.
- */
-type delta = number;
-type FeedsReadCountContextType = {
-	/**
-	 * Returns the delta change for a given feedId.
-	 */
-	getDelta: (feedId: feedId) => delta;
-	/**
-	 *
-	 * @param feedId feedId
-	 * @param delta represents the change amount.
-	 *  e.g : +1, -1.
-	 */
-	updateDelta: (feedId: feedId, delta: delta) => void;
-	/**
-	 * Resets the delata for a given feedId to 0.
-	 *
-	 * @param feedId feedId
-	 */
-	resetDelta: (feedId: feedId) => void;
+type FeedsUnreadCountContextType = {
+	getUnreadCount: (feedId: number, serverUnread: number) => number;
+	setOptimisticUnread: (
+		feedId: number,
+		optimistic: number,
+		baseline: number,
+	) => void;
+	clearOptimistic: (feedId: number) => void;
 };
-const FeedsReadCountContext = createContext<FeedsReadCountContextType | null>(
+const FeedsReadCountContext = createContext<FeedsUnreadCountContextType | null>(
 	null,
 );
 
-export const useFeedsReadCount = () => {
+export const useFeedsUnereadCount = () => {
 	const ctx = useContext(FeedsReadCountContext);
 	if (!ctx) {
 		throw new Error(
@@ -40,40 +26,46 @@ export const useFeedsReadCount = () => {
 	return ctx;
 };
 
-export default function FeedsReadCountProvider({
+export default function FeedsUnreadCountProvider({
 	children,
 }: {
 	children: React.ReactNode;
 }) {
-	const [delta, setDelata] = useState<Map<feedId, delta>>(new Map());
+	const [optimistic, setOptimistic] = useState<
+		Map<feedId, { optimistic: number; baseline: number }>
+	>(new Map());
 
-	const getDelta = (feedId: feedId) => {
-		return delta.get(feedId) ?? 0;
+	const getUnreadCount = (feedId: feedId, serverUnreadCount: number) => {
+		const entry = optimistic.get(feedId);
+		if (!entry) return serverUnreadCount;
+		// server has caught up -> ignore optimistic automatically.
+		if (serverUnreadCount !== entry.baseline) return serverUnreadCount;
+		return entry.optimistic;
 	};
 
-	const updateDelta = (feedId: feedId, delta: number) => {
-		setDelata((prev) => {
-			const current = prev.get(feedId) ?? 0;
+	const setOptimisticUnread = (
+		feedId: number,
+		optimistic: number,
+		baseline: number,
+	) => {
+		setOptimistic((prev) =>
+			new Map(prev).set(feedId, { optimistic, baseline }),
+		);
+	};
+
+	const clearOptimistic = (feedId: number) =>
+		setOptimistic((prev) => {
 			const next = new Map(prev);
-			next.set(feedId, current + delta);
+			next.delete(feedId);
 			return next;
 		});
-	};
-
-	// un/markFeedContentAsRead calls revalidatePath server-side.
-	// By the time the client's startTransition callback finishes, Next.js has already pushed the updated RSC payload,
-	// meaning userFeedsGroupedByFolderPromise resolves with fresh delta.
-	// Calling resetDeltas() at that point ensures the delta doesn't double-subtract from the already-updated server value.
-	const resetDelta = (feedId: feedId) => {
-		setDelata((prev) => new Map(prev).set(feedId, 0));
-	};
 
 	return (
 		<FeedsReadCountContext.Provider
 			value={{
-				getDelta,
-				updateDelta,
-				resetDelta,
+				getUnreadCount,
+				setOptimisticUnread,
+				clearOptimistic,
 			}}
 		>
 			{children}

--- a/src/lib/stores/feeds-read-count-context.tsx
+++ b/src/lib/stores/feeds-read-count-context.tsx
@@ -20,7 +20,7 @@ export const useFeedsUnereadCount = () => {
 	const ctx = useContext(FeedsReadCountContext);
 	if (!ctx) {
 		throw new Error(
-			"useFeedsReadCount must be used within a FeedsReadCountProvider",
+			`${useFeedsUnereadCount.name} must be used within a ${FeedsUnreadCountProvider.name}`,
 		);
 	}
 	return ctx;

--- a/src/lib/stores/feeds-read-count-context.tsx
+++ b/src/lib/stores/feeds-read-count-context.tsx
@@ -1,0 +1,70 @@
+"use client";
+import { createContext, useContext, useState } from "react";
+
+type feedId = number;
+/**
+ * delta represents the change amount.
+ * e.g : +1, -1.
+ */
+type delta = number;
+type FeedsReadCountContextType = {
+	/**
+	 * Returns the read count for a given feedId.
+	 */
+	getReadCount: (feedId: feedId) => delta;
+	/**
+	 *
+	 * @param feedId feedId
+	 * @param delta represents the change amount.
+	 *  e.g : +1, -1.
+	 * @returns
+	 */
+	updateReadCount: (feedId: feedId, delta: delta) => void;
+	/**
+	 * Resets the read count for a given feedId to 0.
+	 *
+	 * @param feedId feedId
+	 */
+	resetReadCount: (feedId: feedId) => void;
+};
+const FeedsReadCountContext = createContext<FeedsReadCountContextType | null>(
+	null,
+);
+
+export const useFeedsReadCount = () => {
+	const ctx = useContext(FeedsReadCountContext);
+	if (!ctx) {
+		throw new Error(
+			"useFeedsReadCount must be used within a FeedsReadCountProvider",
+		);
+	}
+	return ctx;
+};
+
+export default function FeedsReadCountProvider({
+	children,
+}: {
+	children: React.ReactNode;
+}) {
+	const [readCount, setReadCount] = useState<Map<feedId, delta>>(new Map());
+
+	const getReadCount = (feedId: feedId) => {
+		return readCount.get(feedId) ?? 0;
+	};
+
+	const updateReadCount = (feedId: feedId, delta: number) => {
+		setReadCount((prev) => new Map(prev).set(feedId, delta));
+	};
+
+	const resetReadCount = (feedId: feedId) => {
+		setReadCount((prev) => new Map(prev).set(feedId, 0));
+	};
+
+	return (
+		<FeedsReadCountContext.Provider
+			value={{ getReadCount, updateReadCount, resetReadCount }}
+		>
+			{children}
+		</FeedsReadCountContext.Provider>
+	);
+}


### PR DESCRIPTION
En tant qu’utilisateur

Je veux voir le nombre de contenu non lus dans la barre latérale dans /feeds

Afin que je puisse savoir combien de choses que je n’ai pas lu

Au lieu de ce qui est affiché actuellement : le nombre total de contenu

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sidebar badges and totals now reflect server read counts combined with local per-feed deltas.
  * Immediate optimistic mark-as-read/unread with instant badge updates and automatic revert plus user-facing error toasts.

* **Refactor**
  * Removed prior snapshot-based rollback logic for optimistic operations.
  * Added a lightweight provider to track per-feed unread deltas and wrapped sidebar/timeline to use it.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->